### PR TITLE
refactor: jwt 예외 처리 로직 추가

### DIFF
--- a/src/main/java/com/moim/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/moim/backend/domain/user/controller/UserController.java
@@ -6,6 +6,7 @@ import com.moim.backend.domain.user.response.UserResponse;
 import com.moim.backend.domain.user.service.UserService;
 import com.moim.backend.global.auth.Login;
 import com.moim.backend.global.common.CustomResponseEntity;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,7 +30,7 @@ public class UserController {
     }
 
     @PostMapping("/login")
-    public CustomResponseEntity<UserResponse.Login> loginByEmail(@RequestBody UserRequest.Login request) {
+    public CustomResponseEntity<UserResponse.Login> loginByEmail(@Valid @RequestBody UserRequest.Login request) {
         return CustomResponseEntity.success(
                 userService.login(request)
         );

--- a/src/main/java/com/moim/backend/domain/user/request/UserRequest.java
+++ b/src/main/java/com/moim/backend/domain/user/request/UserRequest.java
@@ -1,6 +1,7 @@
 package com.moim.backend.domain.user.request;
 
 import com.moim.backend.domain.user.entity.User;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,7 +12,9 @@ public class UserRequest {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Login {
+        @NotNull(message = "email은 null이 될 수 없습니다.")
         private String email;
+        @NotNull(message = "name은 null이 될 수 없습니다.")
         private String name;
 
         public User toUserEntity() {

--- a/src/main/java/com/moim/backend/global/auth/jwt/JwtService.java
+++ b/src/main/java/com/moim/backend/global/auth/jwt/JwtService.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.context.request.NativeWebRequest;
 
 import java.security.Key;
@@ -44,21 +45,31 @@ public class JwtService implements InitializingBean {
                 .setExpiration(validity)
                 .compact();
     }
+//
+//    public boolean isValidated(String token) {
+//        try {
+//            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+//            return true;
+//        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+//            log.info("잘못된 JWT 서명입니다.");
+//        } catch (ExpiredJwtException e) {
+//            log.info("만료된 JWT 토큰입니다.");
+//        } catch (UnsupportedJwtException e) {
+//            log.info("지원되지 않는 JWT 토큰입니다.");
+//        } catch (IllegalArgumentException e) {
+//            log.info("JWT 토큰이 잘못되었습니다.");
+//        }
+//        return false;
+//    }
 
-    public boolean isValidated(String token) {
+    public boolean isValidated(String token) throws Exception {
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
-        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
-            log.info("잘못된 JWT 서명입니다.");
-        } catch (ExpiredJwtException e) {
-            log.info("만료된 JWT 토큰입니다.");
-        } catch (UnsupportedJwtException e) {
-            log.info("지원되지 않는 JWT 토큰입니다.");
-        } catch (IllegalArgumentException e) {
-            log.info("JWT 토큰이 잘못되었습니다.");
+        } catch (Exception e) {
+            throw new IllegalArgumentException("JWT 토큰이 잘못되었습니다.");
         }
-        return false;
+
     }
 
     public String getUserEmail(String token) {
@@ -70,15 +81,27 @@ public class JwtService implements InitializingBean {
     }
 
     public String getToken(HttpServletRequest request) {
-        return getToken(request.getHeader(HttpHeaders.AUTHORIZATION));
+        String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (authorization == null) {
+            throw new NullPointerException("header에 authorization 값이 없습니다.");
+        }
+
+        return getToken(authorization);
     }
 
     public String getToken(NativeWebRequest request) {
+        String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (authorization == null) {
+            throw new NullPointerException("header에 authorization 값이 없습니다.");
+        }
+
         return getToken(request.getHeader(HttpHeaders.AUTHORIZATION));
     }
 
-    private String getToken(String authorizationValue) {
-        String[] splitAuthorization = authorizationValue.split(" ");
+    private String getToken(String authorization) {
+        String[] splitAuthorization = authorization.split(" ");
         if (splitAuthorization.length > 1) {
             return splitAuthorization[1];
         } else {

--- a/src/main/java/com/moim/backend/global/common/CustomResponseEntity.java
+++ b/src/main/java/com/moim/backend/global/common/CustomResponseEntity.java
@@ -27,6 +27,13 @@ public class CustomResponseEntity<T> {
                 .build();
     }
 
+    public static <T> CustomResponseEntity<T> fail(String message) {
+        return CustomResponseEntity.<T>builder()
+                .code(Result.FAIL.getCode())
+                .message(message)
+                .build();
+    }
+
     public static <T> CustomResponseEntity<T> fail(Result result) {
         return CustomResponseEntity.<T>builder()
                 .result(result)

--- a/src/main/java/com/moim/backend/global/common/Result.java
+++ b/src/main/java/com/moim/backend/global/common/Result.java
@@ -7,8 +7,8 @@ public enum Result {
 
     OK(0, "성공"),
     FAIL(-1, "실패"),
-
     // Space
+    UNEXPECTED_EXCEPTION(-1000, "예상치 못한 예외가 발생했습니다."),
     NOT_FOUND_GROUP(-1001, "존재하지 않는 그룹입니다."),
     INVALID_TRANSPORTATION(-1002, "잘못된 이동수단 입니다.");
 


### PR DESCRIPTION
* 해결한 이슈: #15 
* jwt 토큰 검증 과정에서 예외 발생 시 400 Bad Request 상태 코드와 함께 예외 메세지 반환
* CommonRestExceptionHandler 반복된 코드 제거할 수 있도록 CustomResponseEntity에 fail 메서드 오버로딩