### PR TITLE
feat: kakao login

### DIFF
--- a/src/docs/asciidoc/api/user/user.adoc
+++ b/src/docs/asciidoc/api/user/user.adoc
@@ -16,3 +16,13 @@ include::{snippets}/login-by-email/request-fields.adoc[]
 ==== HTTP Response
 include::{snippets}/login-by-email/http-response.adoc[]
 include::{snippets}/login-by-email/response-fields.adoc[]
+
+=== 카카오 로그인 API
+
+==== HTTP Request Body
+include::{snippets}/login-by-kakao/http-request.adoc[]
+include::{snippets}/login-by-kakao/form-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/login-by-kakao/http-response.adoc[]
+include::{snippets}/login-by-kakao/response-fields.adoc[]

--- a/src/main/java/com/moim/backend/domain/user/config/KakaoProperties.java
+++ b/src/main/java/com/moim/backend/domain/user/config/KakaoProperties.java
@@ -1,0 +1,18 @@
+package com.moim.backend.domain.user.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "kakao")
+public class KakaoProperties {
+
+    private String tokenUri;
+    private String userInfoUri;
+    private String grantType;
+    private String clientId;
+    private String redirectUri;
+
+}

--- a/src/main/java/com/moim/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/moim/backend/domain/user/controller/UserController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -33,6 +34,13 @@ public class UserController {
     public CustomResponseEntity<UserResponse.Login> loginByEmail(@Valid @RequestBody UserRequest.Login request) {
         return CustomResponseEntity.success(
                 userService.login(request)
+        );
+    }
+
+    @PostMapping("/login/kakao")
+    public CustomResponseEntity<UserResponse.Login> loginByKakao(@RequestParam String authorizationCode) {
+        return CustomResponseEntity.success(
+                userService.loginByKakao(authorizationCode)
         );
     }
 

--- a/src/main/java/com/moim/backend/domain/user/request/UserRequest.java
+++ b/src/main/java/com/moim/backend/domain/user/request/UserRequest.java
@@ -1,5 +1,6 @@
 package com.moim.backend.domain.user.request;
 
+import com.moim.backend.domain.user.response.KakaoUserResponse;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -15,6 +16,11 @@ public class UserRequest {
         private String email;
         @NotNull(message = "name은 null이 될 수 없습니다.")
         private String name;
+
+        public Login(KakaoUserResponse kakaoUserResponse) {
+            this.email = kakaoUserResponse.getKakaoAccount().getEmail();
+            this.name = kakaoUserResponse.getProperties().getNickname();
+        }
     }
 
 }

--- a/src/main/java/com/moim/backend/domain/user/response/KakaoTokenResponse.java
+++ b/src/main/java/com/moim/backend/domain/user/response/KakaoTokenResponse.java
@@ -1,0 +1,27 @@
+package com.moim.backend.domain.user.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+    @JsonProperty("token_type")
+    private String tokenType;
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+    @JsonProperty("id_token")
+    private String idToken;
+    @JsonProperty("expires_in")
+    private int expiresIn;
+    private String scope;
+    @JsonProperty("refresh_token_expires_in")
+    private int refreshTokenExpiresIn;
+
+}

--- a/src/main/java/com/moim/backend/domain/user/response/KakaoUserResponse.java
+++ b/src/main/java/com/moim/backend/domain/user/response/KakaoUserResponse.java
@@ -1,0 +1,56 @@
+package com.moim.backend.domain.user.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoUserResponse {
+
+    private long id;
+    @JsonProperty("has_signed_up")
+    private boolean hasSignedUp;
+    @JsonProperty("connected_at")
+    private LocalDateTime connectedAt;
+    private KakaoProperties properties;
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class KakaoProperties {
+        private String nickname;
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class KakaoAccount {
+        @JsonProperty("profile_nickname_needs_agreement")
+        private boolean profileNicknameNeedsAgreement;
+        private KakaoProfile profile;
+        @JsonProperty("has_email")
+        private boolean hasEmail;
+        @JsonProperty("email_needs_agreement")
+        private boolean emailNeedsAgreement;
+        @JsonProperty("is_email_valid")
+        private boolean isEmailValid;
+        @JsonProperty("is_email_verified")
+        private boolean isEmailVerified;
+        private String email;
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class KakaoProfile {
+        private String nickname;
+    }
+
+}

--- a/src/main/java/com/moim/backend/domain/user/response/UserResponse.java
+++ b/src/main/java/com/moim/backend/domain/user/response/UserResponse.java
@@ -1,15 +1,19 @@
 package com.moim.backend.domain.user.response;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 public class UserResponse {
 
     @Getter
+    @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Login {
+        private String email;
+        private String name;
         private String token;
     }
 

--- a/src/main/java/com/moim/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/moim/backend/domain/user/service/UserService.java
@@ -1,20 +1,34 @@
 package com.moim.backend.domain.user.service;
 
+import com.moim.backend.domain.user.config.KakaoProperties;
 import com.moim.backend.domain.user.entity.Users;
 import com.moim.backend.domain.user.repository.UserRepository;
 import com.moim.backend.domain.user.request.UserRequest;
+import com.moim.backend.domain.user.response.KakaoTokenResponse;
+import com.moim.backend.domain.user.response.KakaoUserResponse;
 import com.moim.backend.domain.user.response.UserResponse;
 import com.moim.backend.global.auth.jwt.JwtService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
-
     private final JwtService jwtService;
+    private final KakaoProperties kakaoProperties;
+    private RestTemplate restTemplate = new RestTemplate();
 
     public String getUserNameByToken(Users user) {
         return user.getName();
@@ -24,6 +38,12 @@ public class UserService {
         Users user = saveOrUpdate(request);
 
         return new UserResponse.Login(jwtService.createToken(user.getEmail()));
+    }
+
+    public UserResponse.Login loginByKakao(String authorizationCode) {
+        KakaoTokenResponse kakaoTokenResponse = getKakaoToken(authorizationCode);
+        KakaoUserResponse kakaoUserResponse = getKakaoUserInfo(kakaoTokenResponse);
+        return login(new UserRequest.Login(kakaoUserResponse));
     }
 
     private Users saveOrUpdate(UserRequest.Login request) {
@@ -39,6 +59,32 @@ public class UserService {
                 .email(request.getEmail())
                 .name(request.getName())
                 .build();
+    }
+
+    private KakaoTokenResponse getKakaoToken(String authorizationCode) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", kakaoProperties.getGrantType());
+        params.add("client_id", kakaoProperties.getClientId());
+        params.add("redirect_uri", kakaoProperties.getRedirectUri());
+        params.add("code", authorizationCode);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+        return restTemplate.postForObject(
+                kakaoProperties.getTokenUri(), request, KakaoTokenResponse.class
+        );
+    }
+
+    private KakaoUserResponse getKakaoUserInfo(KakaoTokenResponse kakaoTokenResponse) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.setBearerAuth(kakaoTokenResponse.getAccessToken());
+
+        return restTemplate.postForObject(
+                kakaoProperties.getUserInfoUri(), new HttpEntity<>(headers), KakaoUserResponse.class
+        );
     }
 
 }

--- a/src/main/java/com/moim/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/moim/backend/domain/user/service/UserService.java
@@ -37,7 +37,11 @@ public class UserService {
     public UserResponse.Login login(UserRequest.Login request) {
         Users user = saveOrUpdate(request);
 
-        return new UserResponse.Login(jwtService.createToken(user.getEmail()));
+        return UserResponse.Login.builder()
+                .email(request.getEmail())
+                .name(request.getName())
+                .token(jwtService.createToken(user.getEmail()))
+                .build();
     }
 
     public UserResponse.Login loginByKakao(String authorizationCode) {

--- a/src/main/java/com/moim/backend/global/auth/jwt/JwtService.java
+++ b/src/main/java/com/moim/backend/global/auth/jwt/JwtService.java
@@ -2,7 +2,6 @@ package com.moim.backend.global.auth.jwt;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;

--- a/src/test/java/com/moim/backend/docs/user/UserControllerDocsTest.java
+++ b/src/test/java/com/moim/backend/docs/user/UserControllerDocsTest.java
@@ -9,6 +9,7 @@ import com.moim.backend.domain.user.service.UserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -22,6 +23,8 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.formParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -29,6 +32,7 @@ public class UserControllerDocsTest extends RestDocsSupport {
 
     private final UserService userService = mock(UserService.class);
     private final String token = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ5dS1qdW5nMzE0NzZAbmF2ZXIuY29tIiwiZXhwIjoxNjg5MjYwODM2fQ.cgZ8eFDU_Gz7Z3EghXxoa3v-iXUeQmBZ1AfKCBQZnnqFJ6mqMqGdiTS5uVCF1lIKBarXeD6nEmRZj9Ng94pnHw";
+    private final String authorizationCode = "BecAFGVdZhX-8pSEQAxL6l9B3bzZnPpac0H_FEjDLr4MJUQ90L-NuWJFXs0_gIp6h74ugwo9c5oAAAGJiTbIcg";
 
     @Override
     protected Object initController() {
@@ -101,6 +105,37 @@ public class UserControllerDocsTest extends RestDocsSupport {
                                         .description("상태 메세지"),
                                 fieldWithPath("data").type(JsonFieldType.STRING)
                                         .description("이름")
+                        ))
+                );
+    }
+
+    @DisplayName("카카오 로그인")
+    @Test
+    void kakaoByLogin() throws Exception {
+        // given
+        given(userService.loginByKakao(any()))
+                .willReturn(new UserResponse.Login(token));
+
+        // when // then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.post("/user/login/kakao")
+                                .param("authorizationCode", authorizationCode)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("login-by-kakao",
+                        preprocessResponse(prettyPrint()),
+                        formParameters(
+                                parameterWithName("authorizationCode")
+                                        .description("카카오 인가 코드")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER)
+                                        .description("상태 코드"),
+                                fieldWithPath("message").type(JsonFieldType.STRING)
+                                        .description("상태 메세지"),
+                                fieldWithPath("data.token").type(JsonFieldType.STRING)
+                                        .description("엑세스 토큰(시간, 이메일, 이름에 따라 달라짐)")
                         ))
                 );
     }

--- a/src/test/java/com/moim/backend/docs/user/UserControllerDocsTest.java
+++ b/src/test/java/com/moim/backend/docs/user/UserControllerDocsTest.java
@@ -46,7 +46,11 @@ public class UserControllerDocsTest extends RestDocsSupport {
         UserRequest.Login request = new UserRequest.Login("yujung-31476@naver.com", "김유정");
 
         given(userService.login(any()))
-                .willReturn(new UserResponse.Login(token));
+                .willReturn(UserResponse.Login.builder()
+                        .email("test@gmail.com")
+                        .name("테스터")
+                        .token(token)
+                        .build());
 
         // when // then
         mockMvc.perform(
@@ -70,6 +74,10 @@ public class UserControllerDocsTest extends RestDocsSupport {
                                         .description("상태 코드"),
                                 fieldWithPath("message").type(JsonFieldType.STRING)
                                         .description("상태 메세지"),
+                                fieldWithPath("data.email").type(JsonFieldType.STRING)
+                                        .description("유저 이메일"),
+                                fieldWithPath("data.name").type(JsonFieldType.STRING)
+                                        .description("유저 이름"),
                                 fieldWithPath("data.token").type(JsonFieldType.STRING)
                                         .description("엑세스 토큰(시간, 이메일, 이름에 따라 달라짐)")
                         ))
@@ -80,13 +88,8 @@ public class UserControllerDocsTest extends RestDocsSupport {
     @Test
     void getUserNameByToken() throws Exception {
         // given
-        Users user = Users.builder()
-                        .email("yu-jung31476@naver.com")
-                        .name("김유정")
-                        .build();
-
         given(userService.getUserNameByToken(any()))
-                .willReturn(user.getName());
+                .willReturn("테스터");
 
         // when // then
         mockMvc.perform(
@@ -114,7 +117,11 @@ public class UserControllerDocsTest extends RestDocsSupport {
     void kakaoByLogin() throws Exception {
         // given
         given(userService.loginByKakao(any()))
-                .willReturn(new UserResponse.Login(token));
+                .willReturn(UserResponse.Login.builder()
+                        .email("test@gmail.com")
+                        .name("테스터")
+                        .token(token)
+                        .build());
 
         // when // then
         mockMvc.perform(
@@ -134,6 +141,10 @@ public class UserControllerDocsTest extends RestDocsSupport {
                                         .description("상태 코드"),
                                 fieldWithPath("message").type(JsonFieldType.STRING)
                                         .description("상태 메세지"),
+                                fieldWithPath("data.email").type(JsonFieldType.STRING)
+                                        .description("유저 이메일"),
+                                fieldWithPath("data.name").type(JsonFieldType.STRING)
+                                        .description("유저 이름"),
                                 fieldWithPath("data.token").type(JsonFieldType.STRING)
                                         .description("엑세스 토큰(시간, 이메일, 이름에 따라 달라짐)")
                         ))


### PR DESCRIPTION
* 카카오 로그인 개발 및 API 명세서 작업
* 클라이언트 측에서 로그인 후 인가코드 전달시 로그인 가능
* 로그인 로직: 인가코드로 토큰 가져오기 → 토큰으로 유저 정보 가져와서 저장 또는 업데이트 → 토큰 생성 후 이름과 이메일과 함께 반환