### PR TITLE
feat/refactor : 구글 로그인 API 구현 및 소셜 로그인 로직 통합

### DIFF
--- a/src/docs/asciidoc/api/user/user.adoc
+++ b/src/docs/asciidoc/api/user/user.adoc
@@ -21,8 +21,28 @@ include::{snippets}/login-by-email/response-fields.adoc[]
 
 ==== HTTP Request Body
 include::{snippets}/login-by-kakao/http-request.adoc[]
-include::{snippets}/login-by-kakao/form-parameters.adoc[]
+include::{snippets}/login-by-kakao/query-parameters.adoc[]
 
 ==== HTTP Response
 include::{snippets}/login-by-kakao/http-response.adoc[]
 include::{snippets}/login-by-kakao/response-fields.adoc[]
+
+=== 네이버 로그인 API
+
+==== HTTP Request Body
+include::{snippets}/login-by-naver/http-request.adoc[]
+include::{snippets}/login-by-naver/query-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/login-by-naver/http-response.adoc[]
+include::{snippets}/login-by-naver/response-fields.adoc[]
+
+=== 구글 로그인 API
+
+==== HTTP Request Body
+include::{snippets}/login-by-google/http-request.adoc[]
+include::{snippets}/login-by-google/query-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/login-by-google/http-response.adoc[]
+include::{snippets}/login-by-google/response-fields.adoc[]

--- a/src/main/java/com/moim/backend/domain/user/config/GoogleProperties.java
+++ b/src/main/java/com/moim/backend/domain/user/config/GoogleProperties.java
@@ -1,0 +1,29 @@
+package com.moim.backend.domain.user.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "google")
+public class GoogleProperties {
+    private String requestTokenUri;
+    private String clientId;
+    private String clientSecret;
+    private String redirectUri;
+
+    public Map<String, Object> getRequestParameter(String code) {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("code", code);
+        parameters.put("client_id", clientId);
+        parameters.put("client_secret", clientSecret);
+        parameters.put("redirect_uri", redirectUri);
+        parameters.put("grant_type", "authorization_code");
+        return parameters;
+    }
+}

--- a/src/main/java/com/moim/backend/domain/user/config/GoogleProperties.java
+++ b/src/main/java/com/moim/backend/domain/user/config/GoogleProperties.java
@@ -3,7 +3,6 @@ package com.moim.backend.domain.user.config;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/com/moim/backend/domain/user/config/KakaoProperties.java
+++ b/src/main/java/com/moim/backend/domain/user/config/KakaoProperties.java
@@ -3,6 +3,8 @@ package com.moim.backend.domain.user.config;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 @Data
 @Configuration
@@ -14,5 +16,14 @@ public class KakaoProperties {
     private String grantType;
     private String clientId;
     private String redirectUri;
+
+    public MultiValueMap<String, String> getRequestParameter(String code) {
+        MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+        parameters.add("grant_type", grantType);
+        parameters.add("client_id", clientId);
+        parameters.add("redirect_uri", redirectUri);
+        parameters.add("code", code);
+        return parameters;
+    }
 
 }

--- a/src/main/java/com/moim/backend/domain/user/config/Platform.java
+++ b/src/main/java/com/moim/backend/domain/user/config/Platform.java
@@ -1,0 +1,8 @@
+package com.moim.backend.domain.user.config;
+
+import lombok.Getter;
+
+@Getter
+public enum Platform {
+    NAVER, GOOGLE, KAKAO;
+}

--- a/src/main/java/com/moim/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/moim/backend/domain/user/controller/UserController.java
@@ -1,7 +1,5 @@
 package com.moim.backend.domain.user.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.moim.backend.domain.user.config.Platform;
 import com.moim.backend.domain.user.entity.Users;
 import com.moim.backend.domain.user.request.UserRequest;
 import com.moim.backend.domain.user.response.UserResponse;
@@ -41,9 +39,9 @@ public class UserController {
         );
     }
 
-    @PostMapping("/login/kakao")
-    public CustomResponseEntity<UserResponse.Login> loginByKakao(@RequestParam String authorizationCode) {
-        return CustomResponseEntity.success(userService.loginByOAuth(authorizationCode, KAKAO));
+    @GetMapping("/login/kakao")
+    public CustomResponseEntity<UserResponse.Login> loginByKakao(@RequestParam(name = "code") String code) {
+        return CustomResponseEntity.success(userService.loginByOAuth(code, KAKAO));
     }
 
     @GetMapping("/login/naver")

--- a/src/main/java/com/moim/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/moim/backend/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.moim.backend.domain.user.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.moim.backend.domain.user.config.Platform;
 import com.moim.backend.domain.user.entity.Users;
 import com.moim.backend.domain.user.request.UserRequest;
 import com.moim.backend.domain.user.response.UserResponse;
@@ -15,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import static com.moim.backend.domain.user.config.Platform.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -40,13 +43,16 @@ public class UserController {
 
     @PostMapping("/login/kakao")
     public CustomResponseEntity<UserResponse.Login> loginByKakao(@RequestParam String authorizationCode) {
-        return CustomResponseEntity.success(
-                userService.loginByKakao(authorizationCode)
-        );
+        return CustomResponseEntity.success(userService.loginByOAuth(authorizationCode, KAKAO));
     }
 
     @GetMapping("/login/naver")
     public CustomResponseEntity<UserResponse.Login> loginByNaver(@RequestParam(name = "code") String code) {
-        return CustomResponseEntity.success(userService.loginByNaver(code));
+        return CustomResponseEntity.success(userService.loginByOAuth(code, NAVER));
+    }
+
+    @GetMapping("/login/google")
+    public CustomResponseEntity<UserResponse.Login> loginByGoogle(@RequestParam(name = "code") String code) {
+        return CustomResponseEntity.success(userService.loginByOAuth(code, GOOGLE));
     }
 }

--- a/src/main/java/com/moim/backend/domain/user/response/GoogleTokenResponse.java
+++ b/src/main/java/com/moim/backend/domain/user/response/GoogleTokenResponse.java
@@ -1,0 +1,22 @@
+package com.moim.backend.domain.user.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoogleTokenResponse {
+    @JsonProperty("access_token")
+    private String accessToken;
+    @JsonProperty("expires_in")
+    private Integer expiresIn;
+    @JsonProperty("scope")
+    private String scope;
+    @JsonProperty("token_type")
+    private String tokenType;
+    @JsonProperty("id_token")
+    private String idToken;
+}

--- a/src/main/java/com/moim/backend/domain/user/response/GoogleUserResponse.java
+++ b/src/main/java/com/moim/backend/domain/user/response/GoogleUserResponse.java
@@ -1,0 +1,28 @@
+package com.moim.backend.domain.user.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoogleUserResponse {
+    @JsonProperty("id")
+    private String id;
+    @JsonProperty("email")
+    private String email;
+    @JsonProperty("verified_email")
+    private Boolean verifiedEmail;
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("given_name")
+    private String givenName;
+    @JsonProperty("family_name")
+    private String familyName;
+    @JsonProperty("picture")
+    private String picture;
+    @JsonProperty("locale")
+    private String locale;
+}

--- a/src/main/java/com/moim/backend/domain/user/service/GoogleLoginService.java
+++ b/src/main/java/com/moim/backend/domain/user/service/GoogleLoginService.java
@@ -1,0 +1,72 @@
+package com.moim.backend.domain.user.service;
+
+import com.moim.backend.domain.user.config.GoogleProperties;
+import com.moim.backend.domain.user.entity.Users;
+import com.moim.backend.domain.user.response.GoogleTokenResponse;
+import com.moim.backend.domain.user.response.GoogleUserResponse;
+import com.moim.backend.domain.user.response.NaverUserResponse;
+import com.moim.backend.global.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import static com.moim.backend.global.common.Result.INVALID_ACCESS_INFO;
+import static com.moim.backend.global.common.Result.NOT_AUTHENTICATE_NAVER_TOKEN_INFO;
+
+@Service
+@RequiredArgsConstructor
+public class GoogleLoginService {
+
+    private final GoogleProperties googleProperties;
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    // 유저 Entity 로 변환
+    public Users toEntityUser(String code) {
+        String accessToken = toRequestAccessToken(code);
+        GoogleUserResponse profile = toRequestProfile(accessToken);
+
+        return Users.builder()
+                .email(profile.getEmail())
+                .name(profile.getName())
+                .build();
+    }
+
+    // Google AccessToken 응답
+    private String toRequestAccessToken(String code) {
+        // 발급받은 code -> GET 요청
+        ResponseEntity<GoogleTokenResponse> response = restTemplate.postForEntity(
+                googleProperties.getRequestTokenUri(),
+                googleProperties.getRequestParameter(code),
+                GoogleTokenResponse.class
+        );
+
+        if (!response.getStatusCode().is2xxSuccessful()) {
+            throw new CustomException(NOT_AUTHENTICATE_NAVER_TOKEN_INFO);
+        }
+
+        return response.getBody().getAccessToken();
+    }
+
+    // 유저 정보 응답
+    private GoogleUserResponse toRequestProfile(String accessToken) {
+        // accessToken 헤더 등록
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+
+        // GET 요청으로 유저정보 응답 시도
+        ResponseEntity<GoogleUserResponse> response =
+                restTemplate.exchange("https://www.googleapis.com/oauth2/v1/userinfo", HttpMethod.GET, request, GoogleUserResponse.class);
+
+        if (!response.getStatusCode().is2xxSuccessful()) {
+            throw new CustomException(INVALID_ACCESS_INFO);
+        }
+
+        return response.getBody();
+    }
+}

--- a/src/main/java/com/moim/backend/domain/user/service/GoogleLoginService.java
+++ b/src/main/java/com/moim/backend/domain/user/service/GoogleLoginService.java
@@ -4,7 +4,6 @@ import com.moim.backend.domain.user.config.GoogleProperties;
 import com.moim.backend.domain.user.entity.Users;
 import com.moim.backend.domain.user.response.GoogleTokenResponse;
 import com.moim.backend.domain.user.response.GoogleUserResponse;
-import com.moim.backend.domain.user.response.NaverUserResponse;
 import com.moim.backend.global.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpEntity;
@@ -38,7 +37,7 @@ public class GoogleLoginService {
 
     // Google AccessToken 응답
     private String toRequestAccessToken(String code) {
-        // 발급받은 code -> GET 요청
+        // 발급받은 code -> POST 요청
         ResponseEntity<GoogleTokenResponse> response = restTemplate.postForEntity(
                 googleProperties.getRequestTokenUri(),
                 googleProperties.getRequestParameter(code),

--- a/src/main/java/com/moim/backend/domain/user/service/KakaoLoginService.java
+++ b/src/main/java/com/moim/backend/domain/user/service/KakaoLoginService.java
@@ -1,0 +1,80 @@
+package com.moim.backend.domain.user.service;
+
+import com.moim.backend.domain.user.config.KakaoProperties;
+import com.moim.backend.domain.user.entity.Users;
+import com.moim.backend.domain.user.response.GoogleTokenResponse;
+import com.moim.backend.domain.user.response.GoogleUserResponse;
+import com.moim.backend.domain.user.response.KakaoTokenResponse;
+import com.moim.backend.domain.user.response.KakaoUserResponse;
+import com.moim.backend.global.common.Result;
+import com.moim.backend.global.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import static com.moim.backend.global.common.Result.*;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoLoginService {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final KakaoProperties kakaoProperties;
+
+    // 유저 Entity 로 변환
+    public Users toEntityUser(String code) {
+        String accessToken = toRequestAccessToken(code);
+        KakaoUserResponse profile = toRequestProfile(accessToken);
+
+        return Users.builder()
+                .email(profile.getKakaoAccount().getEmail())
+                .name(profile.getProperties().getNickname())
+                .build();
+    }
+
+    // Google AccessToken 응답
+    private String toRequestAccessToken(String authorizationCode) {
+        // 발급받은 code -> GET 요청
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", kakaoProperties.getGrantType());
+        params.add("client_id", kakaoProperties.getClientId());
+        params.add("redirect_uri", kakaoProperties.getRedirectUri());
+        params.add("code", authorizationCode);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+        ResponseEntity<KakaoTokenResponse> response =
+                restTemplate.postForEntity(kakaoProperties.getTokenUri(), request, KakaoTokenResponse.class);
+
+        if (!response.getStatusCode().is2xxSuccessful()) {
+            throw new CustomException(NOT_AUTHENTICATE_NAVER_TOKEN_INFO);
+        }
+
+        return response.getBody().getAccessToken();
+    }
+
+    // 유저 정보 응답
+    private KakaoUserResponse toRequestProfile(String accessToken) {
+        // accessToken 헤더 등록
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.setBearerAuth(accessToken);
+
+        // GET 요청으로 유저정보 응답 시도
+        ResponseEntity<KakaoUserResponse> response = restTemplate.postForEntity(
+                kakaoProperties.getUserInfoUri(), new HttpEntity<>(headers), KakaoUserResponse.class
+        );
+
+        if (!response.getStatusCode().is2xxSuccessful()) {
+            throw new CustomException(INVALID_ACCESS_INFO);
+        }
+
+        return response.getBody();
+    }
+
+}

--- a/src/main/java/com/moim/backend/domain/user/service/KakaoLoginService.java
+++ b/src/main/java/com/moim/backend/domain/user/service/KakaoLoginService.java
@@ -2,17 +2,12 @@ package com.moim.backend.domain.user.service;
 
 import com.moim.backend.domain.user.config.KakaoProperties;
 import com.moim.backend.domain.user.entity.Users;
-import com.moim.backend.domain.user.response.GoogleTokenResponse;
-import com.moim.backend.domain.user.response.GoogleUserResponse;
 import com.moim.backend.domain.user.response.KakaoTokenResponse;
 import com.moim.backend.domain.user.response.KakaoUserResponse;
-import com.moim.backend.global.common.Result;
 import com.moim.backend.global.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 import static com.moim.backend.global.common.Result.*;
@@ -35,21 +30,17 @@ public class KakaoLoginService {
                 .build();
     }
 
-    // Google AccessToken 응답
-    private String toRequestAccessToken(String authorizationCode) {
-        // 발급받은 code -> GET 요청
+    // Kakao AccessToken 응답
+    private String toRequestAccessToken(String code) {
+        // 발급받은 code -> POST 요청
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("grant_type", kakaoProperties.getGrantType());
-        params.add("client_id", kakaoProperties.getClientId());
-        params.add("redirect_uri", kakaoProperties.getRedirectUri());
-        params.add("code", authorizationCode);
-
-        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
-        ResponseEntity<KakaoTokenResponse> response =
-                restTemplate.postForEntity(kakaoProperties.getTokenUri(), request, KakaoTokenResponse.class);
+        ResponseEntity<KakaoTokenResponse> response = restTemplate.postForEntity(
+                kakaoProperties.getTokenUri(),
+                new HttpEntity<>(kakaoProperties.getRequestParameter(code), headers),
+                KakaoTokenResponse.class
+        );
 
         if (!response.getStatusCode().is2xxSuccessful()) {
             throw new CustomException(NOT_AUTHENTICATE_NAVER_TOKEN_INFO);

--- a/src/main/java/com/moim/backend/domain/user/service/NaverLoginService.java
+++ b/src/main/java/com/moim/backend/domain/user/service/NaverLoginService.java
@@ -1,14 +1,10 @@
 package com.moim.backend.domain.user.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moim.backend.domain.user.config.NaverProperties;
 import com.moim.backend.domain.user.entity.Users;
 import com.moim.backend.domain.user.response.NaverTokenResponse;
 import com.moim.backend.domain.user.response.NaverUserResponse;
-import com.moim.backend.global.common.Result;
 import com.moim.backend.global.common.exception.CustomException;
-import jdk.jshell.Snippet;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/moim/backend/domain/user/service/NaverLoginService.java
+++ b/src/main/java/com/moim/backend/domain/user/service/NaverLoginService.java
@@ -36,7 +36,7 @@ public class NaverLoginService {
     }
 
     // Naver AccessToken 응답
-    public String toRequestAccessToken(String code) {
+    private String toRequestAccessToken(String code) {
         // 발급받은 code -> GET 요청
         ResponseEntity<NaverTokenResponse> response =
                 restTemplate.exchange(naverProperties.getRequestURL(code), HttpMethod.GET, null, NaverTokenResponse.class);
@@ -48,14 +48,14 @@ public class NaverLoginService {
             throw new CustomException(NOT_AUTHENTICATE_NAVER_TOKEN_INFO);
         }
 
-        return "Bearer " + response.getBody().getAccessToken();
+        return response.getBody().getAccessToken();
     }
 
     // 유저 정보 응답
-    public NaverUserResponse.NaverUserDetail toRequestProfile(String accessToken) {
+    private NaverUserResponse.NaverUserDetail toRequestProfile(String accessToken) {
         // accessToken 헤더 등록
         HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", accessToken);
+        headers.setBearerAuth(accessToken);
         HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
 
         // GET 요청으로 유저정보 응답 시도


### PR DESCRIPTION
- 해결한 issue : close #58 

```
switch (platform.name()) {
            case "KAKAO" -> userEntity = kakaoLoginService.toEntityUser(code);
            case "NAVER" -> userEntity = naverLoginService.toEntityUser(code);
            case "GOOGLE" -> userEntity = googleLoginService.toEntityUser(code);
            default -> throw new CustomException(UNEXPECTED_EXCEPTION);
        }
```

각 소셜 로그인을 단일객체로 분리 후 유저 Service에서 향상 switch문으로 구분해서 소셜로그인을 진행하게 로직이 변경되었습니다 🙇‍♂️

### 해야할 거
- 프론트와 소셜로그인 관련해 로직 의논
- 서비스 출시가 다가오면 네이버, 구글 로그인 상품 등록 신청
- 등록 신청 후 소셜 로그인에 서비스가 배포될 도메인 등록