### PR TITLE
feat: 중복 참여 방지 로직 추가

### DIFF
--- a/src/main/java/com/moim/backend/domain/space/repository/ParticipationRepository.java
+++ b/src/main/java/com/moim/backend/domain/space/repository/ParticipationRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ParticipationRepository extends JpaRepository<Participation, Long> {
 
@@ -17,5 +19,7 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
             + "GROUP BY p.group "
             + "HAVING p.group = :group")
     MiddlePoint getMiddlePoint(@Param("group") Groups group);
+
+    int countByGroupAndUserId(Groups group, Long userId);
 
 }

--- a/src/main/java/com/moim/backend/domain/space/repository/ParticipationRepository.java
+++ b/src/main/java/com/moim/backend/domain/space/repository/ParticipationRepository.java
@@ -20,6 +20,7 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
             + "HAVING p.group = :group")
     MiddlePoint getMiddlePoint(@Param("group") Groups group);
 
+    Participation findByGroupAndUserId(Groups group, Long userId);
     int countByGroupAndUserId(Groups group, Long userId);
 
 }

--- a/src/main/java/com/moim/backend/domain/space/request/GroupRequest.java
+++ b/src/main/java/com/moim/backend/domain/space/request/GroupRequest.java
@@ -31,22 +31,22 @@ public class GroupRequest {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class Participate {
-        @NotNull
+        @NotNull(message = "스페이스 아이디를 입력하지 않았습니다.")
         private Long groupId;
 
-        @NotBlank(message = "별명을 입력하지 않았습니다.")
+        @NotBlank(message = "닉네임을 입력하지 않았습니다.")
         private String userName;
 
-        @NotBlank(message = "출발 위치가 입력되지 않았습니다.")
+        @NotBlank(message = "출발 위치가 입력하지 않았습니다.")
         private String locationName;
 
-        @NotNull
+        @NotNull(message = "위도를 입력하지 않았습니다.")
         private Double latitude;
 
-        @NotNull
+        @NotNull(message = "경도를 입력하지 않았습니다.")
         private Double longitude;
 
-        @NotNull
+        @NotNull(message = "이동 수단을 입력하지 않았습니다.")
         private String transportation;
 
         private String password;
@@ -72,7 +72,7 @@ public class GroupRequest {
         @NotNull
         private Long participateId;
 
-        @NotBlank(message = "별명을 입력하지 않았습니다.")
+        @NotBlank(message = "닉네임을 입력하지 않았습니다.")
         private String userName;
 
         @NotBlank(message = "출발 위치가 입력되지 않았습니다.")

--- a/src/main/java/com/moim/backend/domain/space/request/GroupServiceRequest.java
+++ b/src/main/java/com/moim/backend/domain/space/request/GroupServiceRequest.java
@@ -1,11 +1,5 @@
 package com.moim.backend.domain.space.request;
 
-import com.moim.backend.domain.space.entity.Groups;
-import com.moim.backend.domain.space.entity.Participation;
-import com.moim.backend.domain.space.entity.TransportationType;
-import com.moim.backend.domain.user.entity.Users;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.time.LocalDate;

--- a/src/main/java/com/moim/backend/global/common/Result.java
+++ b/src/main/java/com/moim/backend/global/common/Result.java
@@ -24,7 +24,8 @@ public enum Result {
 
     NOT_MATCHED_PARTICIPATE(-1004,"자신의 참여 정보가 아닙니다."),
 
-    NOT_ADMIN_USER(-1005,"해당 유저는 그룹의 어드민이 아닙니다.");
+    NOT_ADMIN_USER(-1005,"해당 유저는 그룹의 어드민이 아닙니다."),
+    DUPLICATE_PARTICIPATION(-1006, "동일한 유저가 이미 스페이스에 참여하고 있습니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/moim/backend/global/common/exception/CommonRestExceptionHandler.java
+++ b/src/main/java/com/moim/backend/global/common/exception/CommonRestExceptionHandler.java
@@ -11,12 +11,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
+
+import java.util.List;
 
 @Slf4j
 @Order(Ordered.HIGHEST_PRECEDENCE)
@@ -55,7 +58,8 @@ public class CommonRestExceptionHandler extends RuntimeException {
     public CustomResponseEntity<Object> handleBadRequest(
             MethodArgumentNotValidException e, HttpServletRequest request
     ) {
-        String errorMessage = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        FieldError error = e.getBindingResult().getFieldErrors().get(0);
+        String errorMessage = "[" + error.getField() + "] " + error.getDefaultMessage();
         log.error("url: \"{}\", message: {}", request.getRequestURI(), errorMessage);
 
         return CustomResponseEntity.fail(errorMessage);

--- a/src/test/java/com/moim/backend/docs/space/GroupControllerDocsTest.java
+++ b/src/test/java/com/moim/backend/docs/space/GroupControllerDocsTest.java
@@ -144,7 +144,7 @@ public class GroupControllerDocsTest extends RestDocsSupport {
                                 fieldWithPath("groupId").type(JsonFieldType.NUMBER)
                                         .description("그룹 ID / Long"),
                                 fieldWithPath("userName").type(JsonFieldType.STRING)
-                                        .description("유저 별명"),
+                                        .description("유저 닉네임"),
                                 fieldWithPath("locationName").type(JsonFieldType.STRING)
                                         .description("출발 위치 이름"),
                                 fieldWithPath("latitude").type(JsonFieldType.NUMBER)
@@ -169,7 +169,7 @@ public class GroupControllerDocsTest extends RestDocsSupport {
                                 fieldWithPath("data.userId").type(JsonFieldType.NUMBER)
                                         .description("유저 ID / Long"),
                                 fieldWithPath("data.userName").type(JsonFieldType.STRING)
-                                        .description("유저 별명"),
+                                        .description("유저 닉네임"),
                                 fieldWithPath("data.locationName").type(JsonFieldType.STRING)
                                         .description("출발 위치"),
                                 fieldWithPath("data.latitude").type(JsonFieldType.NUMBER)
@@ -217,7 +217,7 @@ public class GroupControllerDocsTest extends RestDocsSupport {
                                 fieldWithPath("participateId").type(JsonFieldType.NUMBER)
                                         .description("참여 정보 ID / Long"),
                                 fieldWithPath("userName").type(JsonFieldType.STRING)
-                                        .description("유저 별명"),
+                                        .description("유저 닉네임"),
                                 fieldWithPath("locationName").type(JsonFieldType.STRING)
                                         .description("출발 위치 이름"),
                                 fieldWithPath("latitude").type(JsonFieldType.NUMBER)

--- a/src/test/java/com/moim/backend/domain/space/controller/GroupControllerTest.java
+++ b/src/test/java/com/moim/backend/domain/space/controller/GroupControllerTest.java
@@ -106,7 +106,7 @@ class GroupControllerTest extends ControllerTestSupport {
                 .andExpect(status().isOk());
     }
 
-    @DisplayName("내 참여 정보 수정 API - 별명 미입력 실패")
+    @DisplayName("내 참여 정보 수정 API - 닉네임 미입력 실패")
     @Test
     void participationUpdateFailsWhenUserNameNotProvided() throws Exception {
         // given

--- a/src/test/java/com/moim/backend/domain/space/service/GroupServiceTest.java
+++ b/src/test/java/com/moim/backend/domain/space/service/GroupServiceTest.java
@@ -523,7 +523,8 @@ class GroupServiceTest {
 
     @DisplayName("동일한 유저가 동일한 그룹에 중복으로 참여할 수 없다.")
     @Test
-    void preventDuplicateParticipation() {
+    void throwsExceptionWhenDuplicateParticipation() {
+        //given
         Users user = savedUser("test@gmail.com", "테스터");
         Groups group = savedGroup(user.getUserId(), "테스트 그룹");
         GroupServiceRequest.Participate request = GroupServiceRequest.Participate.builder()
@@ -534,12 +535,12 @@ class GroupServiceTest {
                 .longitude(126.92982)
                 .transportation("BUS")
                 .build();
-        // 첫 참여
         groupService.participateGroup(request, user);
-        // 중복 참여
-        groupService.participateGroup(request, user);
-        assertThat(participationRepository.countByGroupAndUserId(group, user.getUserId()))
-                .isEqualTo(1);
+
+        // when // then
+        assertThatThrownBy(() -> groupService.participateGroup(request, user))
+                .extracting("result.code", "result.message")
+                .contains(Result.DUPLICATE_PARTICIPATION.getCode(), Result.DUPLICATE_PARTICIPATION.getMessage());
     }
 
     // method

--- a/src/test/java/com/moim/backend/domain/space/service/GroupServiceTest.java
+++ b/src/test/java/com/moim/backend/domain/space/service/GroupServiceTest.java
@@ -1,6 +1,5 @@
 package com.moim.backend.domain.space.service;
 
-import com.moim.backend.TestQueryDSLConfig;
 import com.moim.backend.domain.space.entity.BestPlace;
 import com.moim.backend.domain.space.entity.Groups;
 import com.moim.backend.domain.space.entity.Participation;
@@ -9,6 +8,7 @@ import com.moim.backend.domain.space.repository.BestPlaceRepository;
 import com.moim.backend.domain.space.repository.GroupRepository;
 import com.moim.backend.domain.space.repository.ParticipationRepository;
 import com.moim.backend.domain.space.request.GroupRequest;
+import com.moim.backend.domain.space.request.GroupServiceRequest;
 import com.moim.backend.domain.space.response.GroupResponse;
 import com.moim.backend.domain.space.response.KakaoMapDetailDto;
 import com.moim.backend.domain.user.entity.Users;
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -520,6 +519,27 @@ class GroupServiceTest {
                         "02-922-1672", tags, "배달불가",
                         "포장가능", photos, menuInfo
                 );
+    }
+
+    @DisplayName("동일한 유저가 동일한 그룹에 중복으로 참여할 수 없다.")
+    @Test
+    void preventDuplicateParticipation() {
+        Users user = savedUser("test@gmail.com", "테스터");
+        Groups group = savedGroup(user.getUserId(), "테스트 그룹");
+        GroupServiceRequest.Participate request = GroupServiceRequest.Participate.builder()
+                .groupId(group.getGroupId())
+                .userName("테스터")
+                .locationName("불광역")
+                .latitude(37.610553)
+                .longitude(126.92982)
+                .transportation("BUS")
+                .build();
+        // 첫 참여
+        groupService.participateGroup(request, user);
+        // 중복 참여
+        groupService.participateGroup(request, user);
+        assertThat(participationRepository.countByGroupAndUserId(group, user.getUserId()))
+                .isEqualTo(1);
     }
 
     // method


### PR DESCRIPTION
* 해결한 issue: #43 
* 동일한 유저가 동일한 그룹에 참여하게 하는 요청이 들어올 경우, 저장하지 않고 새로운 유저일 경우에만 저장
### 고려해야할 부분
* 동일한 유저가 동일한 그룹에 참여한다는 요청이 들어왔을 때, 가능한 로직은 아래처럼 3가지로 나뉠 수 있음
  1. 새롭게 참여한 경우에만 데이터를 저장한다.
  2. 기존에 참여했지만, 이름, 위도, 경도 중 다른 정보가 있을 경우 업데이트한다.
  3. 동일한 유저가 이미 참여하고 있다고 예외를 발생시킨다.
* 현재(23.07.31 16:43)는 1번을 채택함.
* 이유는 참여 정보를 수정하는 api가 있기 때문에, 기능을 명확하게 분리하기 위함.
* 걱정되는 부분은 클라이언트 측에서 동일한 유저가 참여하고 있지만, 이름이나 위도 경도가 다른경우에는 수정 api를 호출해야하는데, 동일한 유저가 참여하고 있다는 걸 모를 경우 수정 api를 호출하지 않을 수 있음. 하지만, 이런 경우가 드물거라고는 생각됨.
* 이는 다른 분들의 의견을 듣고 수정이 필요한 경우 수정하기