### PR TITLE
refactor : 통합 소셜로그인 API 로직 변경

### DIFF
--- a/src/main/java/com/moim/backend/domain/user/service/GoogleLoginService.java
+++ b/src/main/java/com/moim/backend/domain/user/service/GoogleLoginService.java
@@ -1,6 +1,7 @@
 package com.moim.backend.domain.user.service;
 
 import com.moim.backend.domain.user.config.GoogleProperties;
+import com.moim.backend.domain.user.config.Platform;
 import com.moim.backend.domain.user.entity.Users;
 import com.moim.backend.domain.user.response.GoogleTokenResponse;
 import com.moim.backend.domain.user.response.GoogleUserResponse;
@@ -19,13 +20,19 @@ import static com.moim.backend.global.common.Result.NOT_AUTHENTICATE_NAVER_TOKEN
 
 @Service
 @RequiredArgsConstructor
-public class GoogleLoginService {
+public class GoogleLoginService implements OAuth2LoginService{
 
     private final GoogleProperties googleProperties;
     private final RestTemplate restTemplate = new RestTemplate();
 
-    // 유저 Entity 로 변환
-    public Users toEntityUser(String code) {
+
+    @Override
+    public Platform supports() {
+        return Platform.GOOGLE;
+    }
+
+    @Override
+    public Users toEntityUser(String code, Platform platform) {
         String accessToken = toRequestAccessToken(code);
         GoogleUserResponse profile = toRequestProfile(accessToken);
 

--- a/src/main/java/com/moim/backend/domain/user/service/KakaoLoginService.java
+++ b/src/main/java/com/moim/backend/domain/user/service/KakaoLoginService.java
@@ -1,6 +1,7 @@
 package com.moim.backend.domain.user.service;
 
 import com.moim.backend.domain.user.config.KakaoProperties;
+import com.moim.backend.domain.user.config.Platform;
 import com.moim.backend.domain.user.entity.Users;
 import com.moim.backend.domain.user.response.KakaoTokenResponse;
 import com.moim.backend.domain.user.response.KakaoUserResponse;
@@ -14,13 +15,18 @@ import static com.moim.backend.global.common.Result.*;
 
 @Service
 @RequiredArgsConstructor
-public class KakaoLoginService {
+public class KakaoLoginService implements OAuth2LoginService{
 
     private final RestTemplate restTemplate = new RestTemplate();
     private final KakaoProperties kakaoProperties;
 
-    // 유저 Entity 로 변환
-    public Users toEntityUser(String code) {
+    @Override
+    public Platform supports() {
+        return Platform.KAKAO;
+    }
+
+    @Override
+    public Users toEntityUser(String code, Platform platform) {
         String accessToken = toRequestAccessToken(code);
         KakaoUserResponse profile = toRequestProfile(accessToken);
 
@@ -67,5 +73,4 @@ public class KakaoLoginService {
 
         return response.getBody();
     }
-
 }

--- a/src/main/java/com/moim/backend/domain/user/service/NaverLoginService.java
+++ b/src/main/java/com/moim/backend/domain/user/service/NaverLoginService.java
@@ -1,6 +1,7 @@
 package com.moim.backend.domain.user.service;
 
 import com.moim.backend.domain.user.config.NaverProperties;
+import com.moim.backend.domain.user.config.Platform;
 import com.moim.backend.domain.user.entity.Users;
 import com.moim.backend.domain.user.response.NaverTokenResponse;
 import com.moim.backend.domain.user.response.NaverUserResponse;
@@ -15,13 +16,18 @@ import static com.moim.backend.global.common.Result.*;
 
 @Service
 @RequiredArgsConstructor
-public class NaverLoginService {
+public class NaverLoginService implements OAuth2LoginService{
 
     private final RestTemplate restTemplate = new RestTemplate();
     private final NaverProperties naverProperties;
 
-    // 유저 Entity 로 변환
-    public Users toEntityUser(String code) {
+    @Override
+    public Platform supports() {
+        return Platform.NAVER;
+    }
+
+    @Override
+    public Users toEntityUser(String code, Platform platform) {
         String accessToken = toRequestAccessToken(code);
         NaverUserResponse.NaverUserDetail profile = toRequestProfile(accessToken);
 

--- a/src/main/java/com/moim/backend/domain/user/service/OAuth2LoginService.java
+++ b/src/main/java/com/moim/backend/domain/user/service/OAuth2LoginService.java
@@ -1,0 +1,11 @@
+package com.moim.backend.domain.user.service;
+
+import com.moim.backend.domain.user.config.Platform;
+import com.moim.backend.domain.user.entity.Users;
+
+public interface OAuth2LoginService {
+
+    Platform supports();
+
+    Users toEntityUser(String code, Platform platform);
+}

--- a/src/test/java/com/moim/backend/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/moim/backend/domain/user/service/UserServiceTest.java
@@ -1,0 +1,66 @@
+package com.moim.backend.domain.user.service;
+
+import com.moim.backend.domain.user.config.Platform;
+import com.moim.backend.domain.user.entity.Users;
+import com.moim.backend.domain.user.repository.UserRepository;
+import com.moim.backend.domain.user.response.UserResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.moim.backend.domain.user.config.Platform.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class UserServiceTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @MockBean(value = {GoogleLoginService.class})
+    private OAuth2LoginService oAuth2LoginService;
+
+    @DisplayName("유저가 소셜 로그인을 진행한다.")
+    @Test
+    void loginByOAuth() {
+        // given
+        given(oAuth2LoginService.supports()).willReturn(GOOGLE);
+        given(oAuth2LoginService.toEntityUser(anyString(), any(Platform.class)))
+                .willReturn(
+                        Users.builder()
+                                .email("test@test.com")
+                                .name("소셜테스트")
+                                .build()
+                );
+
+        // when
+        UserResponse.Login response = userService.loginByOAuth(
+                "4%2F0AZEOvhX5fdg6aes78aDsv-H_pxySawXSIiwMOqtbOW3kt6tSxtnSd6_PVOpoemsJF9Q", GOOGLE
+        );
+
+        // then
+        assertThat(response.getToken()).isNotNull();
+
+        assertThat(response)
+                .extracting("email", "name")
+                .contains("test@test.com", "소셜테스트");
+    }
+
+}


### PR DESCRIPTION
### 기존 코드
``` java
    public UserResponse.Login loginByOAuth(String code, Platform platform) {
        // 요청된 로그인 플랫폼 확인 후 소셜 로그인 진행
        Users userEntity;
        switch (platform.name()) {
            case "KAKAO" -> userEntity = kakaoLoginService.toEntityUser(code);
            case "NAVER" -> userEntity = naverLoginService.toEntityUser(code);
            case "GOOGLE" -> userEntity = googleLoginService.toEntityUser(code);
            default -> throw new CustomException(UNEXPECTED_EXCEPTION);

        // 생략
        }
```

### 변경된 코드
```java
    public UserResponse.Login loginByOAuth(String code, Platform platform) {
        // 요청된 로그인 플랫폼 확인 후 소셜 로그인 진행
        Users userEntity = null;

        for (OAuth2LoginService oAuth2LoginService : oAuth2LoginServices) {
            if (oAuth2LoginService.supports().equals(platform)) {
                userEntity = oAuth2LoginService.toEntityUser(code, platform);
                break;
            }
        }

        if (userEntity == null) {
            throw new CustomException(UNEXPECTED_EXCEPTION);
        }

      // 생략
```

- 기존 코드가 OCP 원칙에 위배되는 것을 확인 -> 인터페이스를 이용한 구현체로 loginByOAuth 메서드가 수정되지 않아도 소셜 로그인의 기능이 추가 가능한 형태로 변경
- 소셜로그인 API Service 테스트 작성