### PR TITLE
feat: 모임 지역 추천 로직 완성

### DIFF
--- a/src/main/java/com/moim/backend/domain/hotplace/repository/HotPlaceRepository.java
+++ b/src/main/java/com/moim/backend/domain/hotplace/repository/HotPlaceRepository.java
@@ -1,6 +1,6 @@
-package com.moim.backend.domain.subway.repository;
+package com.moim.backend.domain.hotplace.repository;
 
-import com.moim.backend.domain.subway.entity.Subway;
+import com.moim.backend.domain.hotplace.entity.HotPlace;
 import com.moim.backend.domain.subway.response.BestPlaceInterface;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,16 +10,16 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface SubwayRepository extends JpaRepository<Subway, Long>, SubwayCustomRepository {
+public interface HotPlaceRepository extends JpaRepository<HotPlace, Long> {
 
-    @Query(value = "select CONCAT(name, '역') as name, latitude, longitude, "
+    @Query(value = "select name, latitude, longitude, "
             + "ST_DISTANCE_SPHERE(POINT(longitude, latitude), POINT(:middleLongitude, :middleLatitude)) AS distanceFromMiddlePoint "
-            + "from subway "
+            + "from hot_place "
             + "having distanceFromMiddlePoint <= :validRange "
             + "order by distanceFromMiddlePoint "
             + "limit 3 ", nativeQuery = true)
-    List<BestPlaceInterface> getBestSubwayList( // TODO: 이름이 같은 지하철역은 더 가까운 게 한개만 반환되도록
-            @Param("middleLatitude") double middleLatitude, @Param("middleLongitude") double middleLongitude, @Param("validRange") double validRange
+    List<BestPlaceInterface> getBestHotPlaceList(
+            @Param("middleLatitude") double middleLatit록ude, @Param("middleLongitude") double middleLongitude, @Param("validRange") double validRange
     );
 
 }

--- a/src/main/java/com/moim/backend/domain/space/config/OdsayProperties.java
+++ b/src/main/java/com/moim/backend/domain/space/config/OdsayProperties.java
@@ -1,7 +1,7 @@
 package com.moim.backend.domain.space.config;
 
 import com.moim.backend.domain.space.entity.Participation;
-import com.moim.backend.domain.subway.response.BestSubwayInterface;
+import com.moim.backend.domain.subway.response.BestPlaceInterface;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
@@ -19,7 +19,7 @@ public class OdsayProperties {
     private String searchPathUri;
     private String graphicDataUri;
 
-    public URI getSearchPathUriWithParams(BestSubwayInterface bestSubway, Participation participation) {
+    public URI getSearchPathUriWithParams(BestPlaceInterface bestSubway, Participation participation) {
         return UriComponentsBuilder.fromHttpUrl(searchPathUri)
                 .queryParam("apiKey", apiKey)
                 .queryParam("SX", participation.getLongitude())

--- a/src/main/java/com/moim/backend/domain/space/response/PlaceRouteResponse.java
+++ b/src/main/java/com/moim/backend/domain/space/response/PlaceRouteResponse.java
@@ -2,7 +2,7 @@ package com.moim.backend.domain.space.response;
 
 import com.moim.backend.domain.space.entity.Participation;
 import com.moim.backend.domain.space.entity.TransportationType;
-import com.moim.backend.domain.subway.response.BestSubwayInterface;
+import com.moim.backend.domain.subway.response.BestPlaceInterface;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,25 +20,14 @@ public class PlaceRouteResponse {
     private Double longitude;
     private List<MoveUserInfo> moveUserInfo = new ArrayList<>();
 
-    public PlaceRouteResponse(BestSubwayInterface bestSubway) {
-        this.name = bestSubway.getName();
-        this.latitude = bestSubway.getLatitude();
-        this.longitude = bestSubway.getLongitude();
-    }
-
-    public void addMoveUserInfo(
-            Participation participation,
-            BusGraphicDataResponse busGraphicDataResponse,
-            BusPathResponse busPathResponse
+    public PlaceRouteResponse(
+            BestPlaceInterface bestPlace,
+            List<MoveUserInfo> moveUserInfoList
     ) {
-        this.moveUserInfo.add(new MoveUserInfo(participation, busGraphicDataResponse, busPathResponse));
-    }
-
-    public void addMoveUserInfo(
-            Participation participation,
-            CarMoveInfo carMoveInfo
-    ) {
-        this.moveUserInfo.add(new MoveUserInfo(participation, carMoveInfo));
+        this.name = bestPlace.getName();
+        this.latitude = bestPlace.getLatitude();
+        this.longitude = bestPlace.getLongitude();
+        this.moveUserInfo = moveUserInfoList;
     }
 
     @Getter

--- a/src/main/java/com/moim/backend/domain/space/service/GroupService.java
+++ b/src/main/java/com/moim/backend/domain/space/service/GroupService.java
@@ -2,6 +2,7 @@ package com.moim.backend.domain.space.service;
 
 import com.moim.backend.domain.groupvote.entity.Vote;
 import com.moim.backend.domain.groupvote.repository.VoteRepository;
+import com.moim.backend.domain.hotplace.repository.HotPlaceRepository;
 import com.moim.backend.domain.space.config.OdsayProperties;
 import com.moim.backend.domain.space.entity.BestPlace;
 import com.moim.backend.domain.space.entity.Groups;
@@ -18,13 +19,14 @@ import com.moim.backend.domain.space.response.PlaceRouteResponse;
 import com.moim.backend.domain.space.response.NaverMapListDto;
 import com.moim.backend.domain.subway.entity.Subway;
 import com.moim.backend.domain.subway.repository.SubwayRepository;
-import com.moim.backend.domain.subway.response.BestSubwayInterface;
+import com.moim.backend.domain.subway.response.BestPlaceInterface;
 import com.moim.backend.domain.user.config.KakaoProperties;
 import com.moim.backend.domain.user.entity.Users;
 import com.moim.backend.domain.space.response.BusGraphicDataResponse;
 import com.moim.backend.domain.space.response.BusPathResponse;
 import com.moim.backend.global.common.Result;
 import com.moim.backend.global.common.exception.CustomException;
+import com.moim.backend.global.util.DistanceCalculator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
@@ -47,6 +49,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.StringTokenizer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static com.moim.backend.domain.space.response.GroupResponse.Region.toLocalEntity;
 import static com.moim.backend.domain.space.response.GroupResponse.Participations.toParticipateEntity;
@@ -63,6 +66,7 @@ public class GroupService {
     private final ParticipationRepository participationRepository;
     private final BestPlaceRepository bestPlaceRepository;
     private final SubwayRepository subwayRepository;
+    private final HotPlaceRepository hotPlaceRepository;
     private final OdsayProperties odsayProperties;
     private final KakaoProperties kakaoProperties;
     private final RestTemplate restTemplate = new RestTemplate();
@@ -166,27 +170,30 @@ public class GroupService {
     // 모임 추천 지역 조회하기
     public List<PlaceRouteResponse> getBestRegion(Long groupId) {
         Instant start = Instant.now();
-
         Groups group = getGroup(groupId);
+        // 중간 좌표 구하기
         MiddlePoint middlePoint = participationRepository.getMiddlePoint(group);
-        List<BestSubwayInterface> bestSubwayList = subwayRepository.getBestSubwayList(
-                middlePoint.getLatitude(), middlePoint.getLongitude()
+
+        // 유효범위 찾기
+        List<Participation> participationList = participationRepository.findAllByGroup(group);
+        double validRange = getValidRange(participationList, middlePoint);
+
+        // 근처 지하철역 찾기
+        List<BestPlaceInterface> bestPlaceList = subwayRepository.getBestSubwayList(
+                middlePoint.getLatitude(), middlePoint.getLongitude(), validRange
         );
 
-        List<PlaceRouteResponse> placeRouteResponseList = new ArrayList<>();
-        List<Participation> participations = participationRepository.findAllByGroup(group);
-        bestSubwayList.forEach(bestSubway -> {
-            PlaceRouteResponse placeRouteResponse = new PlaceRouteResponse(bestSubway);
+        // 근처에 지하철역이 없다면, 인기 장소 찾기
+        if (bestPlaceList.isEmpty()) {
+            bestPlaceList = hotPlaceRepository.getBestHotPlaceList(
+                    middlePoint.getLatitude(), middlePoint.getLongitude(), validRange
+            );
+        }
 
-            for (Participation participation : participations) {
-                if ((participation.getTransportation() == TransportationType.PUBLIC)) {
-                    addBusRouteToResponse(bestSubway, participation, placeRouteResponse);
-                } else {
-                    addCarRouteToResponse(bestSubway, participation, placeRouteResponse);
-                }
-            }
-            placeRouteResponseList.add(placeRouteResponse);
-        });
+        // 경로 찾기
+        List<PlaceRouteResponse> placeRouteResponseList = bestPlaceList.stream().map(bestPlace ->
+                new PlaceRouteResponse(bestPlace, getMoveUserInfoList(bestPlace, participationList))
+        ).collect(Collectors.toList());
 
         Instant end = Instant.now();
         log.info("[ 추천 지역 조회 시간: {}ms ] ========================================", Duration.between(start, end).toMillis());
@@ -319,7 +326,7 @@ public class GroupService {
             GroupResponse.Place response = GroupResponse.Place.response(naver, local);
             double placeX = Double.parseDouble(naver.getX());
             double placeY = Double.parseDouble(naver.getY());
-            String distance = String.format("%s(으)로부터 %sm", local, (int) calculateDistance(y, x, placeY, placeX, "meter"));
+            String distance = String.format("%s(으)로부터 %sm", local, (int) DistanceCalculator.getDistance(y, x, placeY, placeX));
             response.setDistance(distance);
             return response;
         };
@@ -329,33 +336,6 @@ public class GroupService {
         return groupRepository.findByGroupParticipation(groupId).orElseThrow(
                 () -> new CustomException(NOT_FOUND_GROUP)
         );
-    }
-
-    private static double calculateDistance(double lat1, double lon1, double lat2, double lon2, String unit) {
-
-        double theta = lon1 - lon2;
-        double dist = Math.sin(deg2rad(lat1)) * Math.sin(deg2rad(lat2)) + Math.cos(deg2rad(lat1)) * Math.cos(deg2rad(lat2)) * Math.cos(deg2rad(theta));
-
-        dist = Math.acos(dist);
-        dist = rad2deg(dist);
-        dist = dist * 60 * 1.1515;
-
-        if (unit.equals("kilometer")) {
-            dist = dist * 1.609344;
-        } else if (unit.equals("meter")) {
-            dist = dist * 1609.344;
-        }
-
-        return (dist);
-    }
-
-
-    private static double deg2rad(double deg) {
-        return (deg * Math.PI / 180.0);
-    }
-
-    private static double rad2deg(double rad) {
-        return (rad * 180 / Math.PI);
     }
 
     private Groups getGroup(Long groupId) {
@@ -409,22 +389,42 @@ public class GroupService {
         );
     }
 
-    private void addBusRouteToResponse(
-            BestSubwayInterface bestSubway, Participation participation, PlaceRouteResponse placeRouteResponse
+    private List<PlaceRouteResponse.MoveUserInfo> getMoveUserInfoList(
+            BestPlaceInterface bestPlace,
+            List<Participation> participationList
+    ) {
+        List<PlaceRouteResponse.MoveUserInfo> moveUserInfoList = new ArrayList<>();
+
+        participationList.forEach(participation -> {
+            if ((participation.getTransportation() == TransportationType.PUBLIC)) {
+                getBusRouteToResponse(bestPlace, participation)
+                        .ifPresent(moveUserInfo -> moveUserInfoList.add(moveUserInfo));
+            } else if (participation.getTransportation() == TransportationType.PERSONAL) {
+                getCarRouteToResponse(bestPlace, participation)
+                        .ifPresent(moveUserInfo -> moveUserInfoList.add(moveUserInfo));
+            }
+        });
+
+        return moveUserInfoList;
+    }
+
+    private Optional<PlaceRouteResponse.MoveUserInfo> getBusRouteToResponse(
+            BestPlaceInterface bestPlace, Participation participation
     ) {
         Instant start = Instant.now();
 
+        Optional<PlaceRouteResponse.MoveUserInfo> moveUserInfo = Optional.empty();
         BusPathResponse busPathResponse = restTemplate.getForObject(
-                odsayProperties.getSearchPathUriWithParams(bestSubway, participation),
+                odsayProperties.getSearchPathUriWithParams(bestPlace, participation),
                 BusPathResponse.class
         );
 
         if (busPathResponse.getResult() == null) {
             log.debug("[ 버스 길찾기 실패 ] ========================================");
-            log.debug("지역: {}, url: {}", bestSubway.getName(), odsayProperties.getSearchPathUriWithParams(bestSubway, participation));
+            log.debug("지역: {}, url: {}", bestPlace.getName(), odsayProperties.getSearchPathUriWithParams(bestPlace, participation));
         } else {
             log.debug("[ 버스 길찾기 성공 ] ========================================");
-            log.debug("지역: {}, url: {}", bestSubway.getName(), odsayProperties.getSearchPathUriWithParams(bestSubway, participation));
+            log.debug("지역: {}, url: {}", bestPlace.getName(), odsayProperties.getSearchPathUriWithParams(bestPlace, participation));
 
             BusGraphicDataResponse busGraphicDataResponse = restTemplate.getForObject(
                     odsayProperties.getGraphicDataUriWIthParams(busPathResponse.getPathInfoMapObj()),
@@ -432,46 +432,62 @@ public class GroupService {
             );
             if (busPathResponse.getResult() == null) {
                 log.debug("[ 버스 그래픽 데이터 조회 실패 ] ========================================");
-                log.debug("지역: {}, url: {}", bestSubway.getName(), odsayProperties.getSearchPathUriWithParams(bestSubway, participation));
+                log.debug("지역: {}, url: {}", bestPlace.getName(), odsayProperties.getSearchPathUriWithParams(bestPlace, participation));
             } else {
                 log.debug("[ 버스 그래픽 데이터 조회 성공 ] ========================================");
-                log.debug("지역: {}, url: {}", bestSubway.getName(), odsayProperties.getSearchPathUriWithParams(bestSubway, participation));
+                log.debug("지역: {}, url: {}", bestPlace.getName(), odsayProperties.getSearchPathUriWithParams(bestPlace, participation));
 
-                placeRouteResponse.addMoveUserInfo(participation, busGraphicDataResponse, busPathResponse);
+                moveUserInfo = Optional.of(new PlaceRouteResponse.MoveUserInfo(participation, busGraphicDataResponse, busPathResponse));
             }
         }
 
         Instant end = Instant.now();
         log.info("[ 버스 경로 조회 시간: {}ms ] ========================================", Duration.between(start, end).toMillis());
+        return moveUserInfo;
     }
 
-    private void addCarRouteToResponse(
-            BestSubwayInterface bestSubway, Participation participation, PlaceRouteResponse placeRouteResponse
+    private Optional<PlaceRouteResponse.MoveUserInfo> getCarRouteToResponse(
+            BestPlaceInterface bestPlace, Participation participation
     ) {
         Instant start = Instant.now();
 
+        Optional<PlaceRouteResponse.MoveUserInfo> moveUserInfo = Optional.empty();
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "KakaoAK " + kakaoProperties.getClientId());
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
         CarMoveInfo carMoveInfo = restTemplate.exchange(
-                kakaoProperties.getSearchCarPathUriWithParams(bestSubway, participation),
+                kakaoProperties.getSearchCarPathUriWithParams(bestPlace, participation),
                 HttpMethod.GET,
                 new HttpEntity<>(headers),
                 CarMoveInfo.class
         ).getBody();
         if (carMoveInfo.getRoutes() == null) {
             log.debug("[ 차 길찾기 조회 실패 ] ========================================");
-            log.debug("지역: {}, url: {}", bestSubway.getName(), kakaoProperties.getSearchCarPathUriWithParams(bestSubway, participation));
+            log.debug("지역: {}, url: {}", bestPlace.getName(), kakaoProperties.getSearchCarPathUriWithParams(bestPlace, participation));
         } else {
             log.debug("[ 차 길찾기 조회 성공 ] ========================================");
-            log.debug("지역: {}, url: {}", bestSubway.getName(), kakaoProperties.getSearchCarPathUriWithParams(bestSubway, participation));
+            log.debug("지역: {}, url: {}", bestPlace.getName(), kakaoProperties.getSearchCarPathUriWithParams(bestPlace, participation));
 
-            placeRouteResponse.addMoveUserInfo(participation, carMoveInfo);
+            moveUserInfo = Optional.of(new PlaceRouteResponse.MoveUserInfo(participation, carMoveInfo));
         }
 
         Instant end = Instant.now();
         log.info("[ 차 경로 조회 시간: {}ms ] ========================================", Duration.between(start, end).toMillis());
+        return moveUserInfo;
+    }
+
+    private double getValidRange(List<Participation> participationList, MiddlePoint middlePoint) {
+        double maxDistance = participationList.stream().mapToDouble(participation ->
+                DistanceCalculator.getDistance(
+                        participation.getLatitude(),
+                        participation.getLongitude(),
+                        middlePoint.getLatitude(),
+                        middlePoint.getLongitude()
+                )
+        ).max().getAsDouble();
+
+        return maxDistance / 2;
     }
 
 }

--- a/src/main/java/com/moim/backend/domain/subway/response/BestPlace.java
+++ b/src/main/java/com/moim/backend/domain/subway/response/BestPlace.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class BestSubway implements BestSubwayInterface {
+public class BestPlace implements BestPlaceInterface {
 
     private String name;
     private double latitude;
@@ -14,7 +14,7 @@ public class BestSubway implements BestSubwayInterface {
     private double distanceFromMiddlePoint;
 
     @Builder
-    public BestSubway(String name, double latitude, double longitude, double distanceFromMiddlePoint) {
+    public BestPlace(String name, double latitude, double longitude, double distanceFromMiddlePoint) {
         this.name = name;
         this.latitude = latitude;
         this.longitude = longitude;

--- a/src/main/java/com/moim/backend/domain/subway/response/BestPlaceInterface.java
+++ b/src/main/java/com/moim/backend/domain/subway/response/BestPlaceInterface.java
@@ -1,6 +1,6 @@
 package com.moim.backend.domain.subway.response;
 
-public interface BestSubwayInterface {
+public interface BestPlaceInterface {
 
     public String getName();
     public double getLatitude();

--- a/src/main/java/com/moim/backend/domain/user/config/KakaoProperties.java
+++ b/src/main/java/com/moim/backend/domain/user/config/KakaoProperties.java
@@ -1,7 +1,7 @@
 package com.moim.backend.domain.user.config;
 
 import com.moim.backend.domain.space.entity.Participation;
-import com.moim.backend.domain.subway.response.BestSubwayInterface;
+import com.moim.backend.domain.subway.response.BestPlaceInterface;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
@@ -32,7 +32,7 @@ public class KakaoProperties {
         return parameters;
     }
 
-    public URI getSearchCarPathUriWithParams(BestSubwayInterface bestSubway, Participation participation) {
+    public URI getSearchCarPathUriWithParams(BestPlaceInterface bestSubway, Participation participation) {
         return UriComponentsBuilder.fromHttpUrl(searchPathUri)
                 .queryParam("origin", participation.getLongitude() + "," + participation.getLatitude())
                 .queryParam("destination", bestSubway.getLongitude() + "," + bestSubway.getLatitude())

--- a/src/main/java/com/moim/backend/global/util/DistanceCalculator.java
+++ b/src/main/java/com/moim/backend/global/util/DistanceCalculator.java
@@ -1,0 +1,19 @@
+package com.moim.backend.global.util;
+
+public final class DistanceCalculator {
+
+    private static final int EARTH_RADIUS = 6371;
+    private static final int KM_TO_M = 1000;
+
+    //두 지점 간의 거리 계산
+    public static double getDistance(double startLatitude, double startLongitude, double endLatitude, double endLongitude) {
+        double dLat = Math.toRadians(endLatitude - startLatitude);
+        double dLon = Math.toRadians(endLongitude - startLongitude);
+
+        double a = Math.sin(dLat/2) * Math.sin(dLat/2) + Math.cos(Math.toRadians(startLatitude)) * Math.cos(Math.toRadians(endLatitude)) * Math.sin(dLon/2) * Math.sin(dLon/2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+
+        return EARTH_RADIUS * c * KM_TO_M;
+    }
+
+}


### PR DESCRIPTION
* 해결한 이슈: #44

### 변경요소
* 근처 지하철역 없으면 인기지역 반환하도록 로직 추가
* 거리 계산하기용 Util 만들고, GroupService에서 관련 로직 제거
* 경로 찾기 로직 리팩토링
  * 기존: moveUserInfo는 비어있는 PlaceRouteResponse 를 만들고, 경로 찾을 때마다 추가하는 형식
  * 변경: 주어진 지하철 정보와 참여자 정보로 moveUserInfo 리스트를 만든 후, 생성자를 통해 PlaceRouteResponse 만드는 형식
  * 변경 이유: 가독성. 로직을 더 읽기 쉽게 만들기 위해

### 고려해봐야할 점
* 인기지역도 유효 범위 체크 후 안되면 원래 중간좌표를 반환해주기로 했는데, 중간좌표가 지도상에 표기가 어려운 경우가 있음(예: 경도 - 126.99999, 위도 - 37.633333333) -> 현재는 우선 인기지역은 무조건 반환되도록 되어있음