### PR TITLE
모임 추천 지역 조회 시 모임장 여부 구분 필드 추가

### DIFF
--- a/src/main/java/com/moim/backend/domain/space/response/PlaceRouteResponse.java
+++ b/src/main/java/com/moim/backend/domain/space/response/PlaceRouteResponse.java
@@ -1,5 +1,6 @@
 package com.moim.backend.domain.space.response;
 
+import com.moim.backend.domain.space.entity.Groups;
 import com.moim.backend.domain.space.entity.Participation;
 import com.moim.backend.domain.space.entity.TransportationType;
 import com.moim.backend.domain.subway.response.BestPlaceInterface;
@@ -34,6 +35,7 @@ public class PlaceRouteResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class MoveUserInfo {
+        private Boolean isAdmin;
         private Long userId;
         private String userName;
         private TransportationType transportationType;
@@ -43,10 +45,12 @@ public class PlaceRouteResponse {
         private List<PathDto> path;
 
         public MoveUserInfo(
+                Groups group,
                 Participation participation,
                 BusGraphicDataResponse busGraphicDataResponse,
                 BusPathResponse busPathResponse
         ) {
+            this.isAdmin = (participation.getUserId() == group.getAdminId()) ? true : false;
             this.userId = participation.getUserId();
             this.userName = participation.getUserName();
             this.transportationType = participation.getTransportation();
@@ -57,9 +61,11 @@ public class PlaceRouteResponse {
         }
 
         public MoveUserInfo(
+                Groups group,
                 Participation participation,
                 CarMoveInfo carMoveInfo
         ) {
+            this.isAdmin = (participation.getUserId() == group.getAdminId()) ? true : false;
             this.userId = participation.getUserId();
             this.userName = participation.getUserName();
             this.transportationType = participation.getTransportation();

--- a/src/main/java/com/moim/backend/domain/space/service/GroupService.java
+++ b/src/main/java/com/moim/backend/domain/space/service/GroupService.java
@@ -199,7 +199,7 @@ public class GroupService {
 
         // 경로 찾기
         List<PlaceRouteResponse> placeRouteResponseList = bestPlaceList.stream().map(bestPlace ->
-                new PlaceRouteResponse(bestPlace, getMoveUserInfoList(bestPlace, participationList))
+                new PlaceRouteResponse(bestPlace, getMoveUserInfoList(bestPlace, group, participationList))
         ).collect(Collectors.toList());
 
         Instant end = Instant.now();
@@ -406,16 +406,17 @@ public class GroupService {
 
     private List<PlaceRouteResponse.MoveUserInfo> getMoveUserInfoList(
             BestPlaceInterface bestPlace,
+            Groups group,
             List<Participation> participationList
     ) {
         List<PlaceRouteResponse.MoveUserInfo> moveUserInfoList = new ArrayList<>();
 
         participationList.forEach(participation -> {
             if ((participation.getTransportation() == TransportationType.PUBLIC)) {
-                getBusRouteToResponse(bestPlace, participation)
+                getBusRouteToResponse(bestPlace, group, participation)
                         .ifPresent(moveUserInfo -> moveUserInfoList.add(moveUserInfo));
             } else if (participation.getTransportation() == TransportationType.PERSONAL) {
-                getCarRouteToResponse(bestPlace, participation)
+                getCarRouteToResponse(bestPlace, group, participation)
                         .ifPresent(moveUserInfo -> moveUserInfoList.add(moveUserInfo));
             }
         });
@@ -424,7 +425,7 @@ public class GroupService {
     }
 
     private Optional<PlaceRouteResponse.MoveUserInfo> getBusRouteToResponse(
-            BestPlaceInterface bestPlace, Participation participation
+            BestPlaceInterface bestPlace, Groups group, Participation participation
     ) {
         Instant start = Instant.now();
 
@@ -452,7 +453,7 @@ public class GroupService {
                 log.debug("[ 버스 그래픽 데이터 조회 성공 ] ========================================");
                 log.debug("지역: {}, url: {}", bestPlace.getName(), odsayProperties.getSearchPathUriWithParams(bestPlace, participation));
 
-                moveUserInfo = Optional.of(new PlaceRouteResponse.MoveUserInfo(participation, busGraphicDataResponse, busPathResponse));
+                moveUserInfo = Optional.of(new PlaceRouteResponse.MoveUserInfo(group, participation, busGraphicDataResponse, busPathResponse));
             }
         }
 
@@ -462,7 +463,7 @@ public class GroupService {
     }
 
     private Optional<PlaceRouteResponse.MoveUserInfo> getCarRouteToResponse(
-            BestPlaceInterface bestPlace, Participation participation
+            BestPlaceInterface bestPlace, Groups group, Participation participation
     ) {
         Instant start = Instant.now();
 
@@ -484,7 +485,7 @@ public class GroupService {
             log.debug("[ 차 길찾기 조회 성공 ] ========================================");
             log.debug("지역: {}, url: {}", bestPlace.getName(), kakaoProperties.getSearchCarPathUriWithParams(bestPlace, participation));
 
-            moveUserInfo = Optional.of(new PlaceRouteResponse.MoveUserInfo(participation, carMoveInfo));
+            moveUserInfo = Optional.of(new PlaceRouteResponse.MoveUserInfo(group, participation, carMoveInfo));
         }
 
         Instant end = Instant.now();

--- a/src/test/java/com/moim/backend/docs/space/GroupControllerDocsTest.java
+++ b/src/test/java/com/moim/backend/docs/space/GroupControllerDocsTest.java
@@ -374,8 +374,8 @@ public class GroupControllerDocsTest extends RestDocsSupport {
 
         // given
         List<PlaceRouteResponse.MoveUserInfo> moveUserInfoList = List.of(
-                new PlaceRouteResponse.MoveUserInfo(1L, "김유정", PUBLIC, 2, 68, 15928.0, path),
-                new PlaceRouteResponse.MoveUserInfo(2L, "천현우", PUBLIC, 2, 96, 27725.0, path)
+                new PlaceRouteResponse.MoveUserInfo(true, 1L, "김유정", PUBLIC, 2, 68, 15928.0, path),
+                new PlaceRouteResponse.MoveUserInfo(false, 2L, "천현우", PUBLIC, 2, 96, 27725.0, path)
         );
         List<PlaceRouteResponse> placeRouteResponseList = List.of(
                 new PlaceRouteResponse("안국", 37.576477, 126.985443, moveUserInfoList),


### PR DESCRIPTION
* 모임장 여부 구분을 위한 "isAdmin" 필드 추가
* 응답 예시
```
{
    "code": 0,
    "message": "성공",
    "data": [
        {
            "name": "노량진역",
            "latitude": 37.513534,
            "longitude": 126.941005,
            "moveUserInfo": [
                {
                    "isAdmin": true,
                    "userId": 4,
                    "userName": "김유정",
                    "transportationType": "PUBLIC",
                    "transitCount": 2,
                    "totalTime": 44,
                    "totalDistance": 9406.0,
                    "path": [
                        {
                            "x": 126.8584671,
                            "y": 37.4948413
                        },
                        {
                            "x": 126.862355,
                            "y": 37.496592
                        },
                        ...
                }, ...
            ]
        }, ...
    ]
}