### PR TITLE
feat: refresh token 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,10 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+
+    // Redis
+    implementation('org.springframework.boot:spring-boot-starter-data-redis')
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/moim/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/moim/backend/domain/user/controller/UserController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -38,4 +39,13 @@ public class UserController {
     ) {
         return CustomResponseEntity.success(userService.loginByOAuth(code, platform));
     }
+
+    // 엑세스 토큰 재발급
+    @GetMapping("/refresh")
+    public CustomResponseEntity<UserResponse.NewAccessToken> reissueAccessToken(
+            @RequestHeader(name = "refreshToken") String refreshToken
+    ) {
+        return CustomResponseEntity.success(userService.reissueAccessToken(refreshToken));
+    }
+
 }

--- a/src/main/java/com/moim/backend/domain/user/response/UserResponse.java
+++ b/src/main/java/com/moim/backend/domain/user/response/UserResponse.java
@@ -15,15 +15,25 @@ public class UserResponse {
     public static class Login {
         private String email;
         private String name;
-        private String token;
+        private String accessToken;
+        private String refreshToken;
 
-        public static Login response(Users user, String token) {
+        public static Login response(Users user, String token, String refreshToken) {
             return Login.builder()
                     .email(user.getEmail())
                     .name(user.getName())
-                    .token(token)
+                    .accessToken(token)
+                    .refreshToken(refreshToken)
                     .build();
         }
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class NewAccessToken {
+        private String accessToken;
     }
 
 }

--- a/src/main/java/com/moim/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/moim/backend/domain/user/service/UserService.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.moim.backend.global.common.Result.FAIL_SOCIAL_LOGIN;
-import static com.moim.backend.global.common.Result.UNEXPECTED_EXCEPTION;
 
 @Service
 @RequiredArgsConstructor
@@ -35,11 +34,15 @@ public class UserService {
         Users user = saveOrUpdate(userEntity);
 
         // 서비스 JWT 토큰 발급
-        String accessToken = jwtService.createToken(user.getEmail());
+        String accessToken = jwtService.createAccessToken(user.getEmail());
+        String refreshToken = jwtService.createRefreshToken(user.getEmail());
 
-        return UserResponse.Login.response(user, accessToken);
+        return UserResponse.Login.response(user, accessToken, refreshToken);
     }
 
+    public UserResponse.NewAccessToken reissueAccessToken(String refreshToken) {
+        return new UserResponse.NewAccessToken(jwtService.reissueAccessToken(refreshToken));
+    }
 
     // method
     private Users oauthLoginProcess(String code, Platform platform) {

--- a/src/main/java/com/moim/backend/global/auth/LoginInterceptor.java
+++ b/src/main/java/com/moim/backend/global/auth/LoginInterceptor.java
@@ -27,7 +27,7 @@ public class LoginInterceptor implements HandlerInterceptor {
         String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
         if (authorization != null) {
             String token = jwtService.getToken(Optional.of(authorization));
-            return jwtService.isValidated(token);
+            jwtService.validateToken(token);
         }
 
         return true;

--- a/src/main/java/com/moim/backend/global/auth/jwt/JwtProperties.java
+++ b/src/main/java/com/moim/backend/global/auth/jwt/JwtProperties.java
@@ -11,6 +11,7 @@ public class JwtProperties {
 
     private String header;
     private String secret;
-    private long tokenValidityInSeconds;
+    private long tokenValidityInMinutes;
+    private long refreshTokenValidityInMinutes;
 
 }

--- a/src/main/java/com/moim/backend/global/common/RedisKeyPrefix.java
+++ b/src/main/java/com/moim/backend/global/common/RedisKeyPrefix.java
@@ -1,0 +1,16 @@
+package com.moim.backend.global.common;
+
+import lombok.Getter;
+
+@Getter
+public enum RedisKeyPrefix {
+
+    REFRESH_TOKEN("refresh_");
+
+    private String prefix;
+
+    RedisKeyPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+}

--- a/src/main/java/com/moim/backend/global/common/exception/CommonRestExceptionHandler.java
+++ b/src/main/java/com/moim/backend/global/common/exception/CommonRestExceptionHandler.java
@@ -118,10 +118,9 @@ public class CommonRestExceptionHandler extends RuntimeException {
     public CustomResponseEntity<String> expiredJwtExceptionHandler(
             ExpiredJwtException e, HttpServletRequest request
     ) {
-        String errorMessage = "만료된 JWT 토큰입니다.";
-        log.error("url: \"{}\", message: {}", request.getRequestURI(), errorMessage);
+        log.error("url: \"{}\", message: {}", request.getRequestURI(), e.getMessage());
 
-        return CustomResponseEntity.fail(errorMessage);
+        return CustomResponseEntity.fail(e.getMessage());
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/moim/backend/global/config/RedisConfig.java
+++ b/src/main/java/com/moim/backend/global/config/RedisConfig.java
@@ -1,0 +1,78 @@
+package com.moim.backend.global.config;
+
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.SslOptions;
+import io.lettuce.core.protocol.ProtocolVersion;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.io.IOException;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    @Value("${spring.data.redis.port}")
+    public int port;
+    @Value("${spring.data.redis.host}")
+    public String host;
+    @Value("${spring.data.redis.ssl.enabled}")
+    private boolean sslEnabled;
+    private final ResourceLoader resourceLoader;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+    }
+
+//    @Bean
+//    LettuceConnectionFactory redisConnectionFactory() {
+//        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+//        redisStandaloneConfiguration.setHostName(host);
+//        redisStandaloneConfiguration.setPort(port);
+//
+//        LettuceClientConfiguration.LettuceClientConfigurationBuilder lettuceClientConfigurationBuilder =
+//                LettuceClientConfiguration.builder();
+//
+//        if (sslEnabled) {
+//            SslOptions sslOptions = null;
+//            try {
+//                sslOptions = SslOptions.builder()
+//                        .trustManager(resourceLoader.getResource("classpath:secret/redis.pem").getFile())
+//                        .build();
+//            } catch (IOException e) {
+//                throw new RuntimeException(e);
+//            }
+//
+//            ClientOptions clientOptions = ClientOptions
+//                    .builder()
+//                    .sslOptions(sslOptions)
+//                    .protocolVersion(ProtocolVersion.RESP3)
+//                    .build();
+//
+//            lettuceClientConfigurationBuilder
+//                    .clientOptions(clientOptions)
+//                    .useSsl();
+//        }
+//
+//        LettuceClientConfiguration lettuceClientConfiguration = lettuceClientConfigurationBuilder.build();
+//
+//        return new LettuceConnectionFactory(redisStandaloneConfiguration, lettuceClientConfiguration);
+//    }
+
+    @Bean
+    RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        return template;
+    }
+
+}

--- a/src/main/java/com/moim/backend/global/config/RedisConfig.java
+++ b/src/main/java/com/moim/backend/global/config/RedisConfig.java
@@ -1,20 +1,14 @@
 package com.moim.backend.global.config;
 
-import io.lettuce.core.ClientOptions;
-import io.lettuce.core.SslOptions;
-import io.lettuce.core.protocol.ProtocolVersion;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ResourceLoader;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
-import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 
-import java.io.IOException;
 
 @Configuration
 @RequiredArgsConstructor
@@ -24,49 +18,11 @@ public class RedisConfig {
     public int port;
     @Value("${spring.data.redis.host}")
     public String host;
-    @Value("${spring.data.redis.ssl.enabled}")
-    private boolean sslEnabled;
-    private final ResourceLoader resourceLoader;
 
     @Bean
     public LettuceConnectionFactory redisConnectionFactory() {
         return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
     }
-
-//    @Bean
-//    LettuceConnectionFactory redisConnectionFactory() {
-//        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
-//        redisStandaloneConfiguration.setHostName(host);
-//        redisStandaloneConfiguration.setPort(port);
-//
-//        LettuceClientConfiguration.LettuceClientConfigurationBuilder lettuceClientConfigurationBuilder =
-//                LettuceClientConfiguration.builder();
-//
-//        if (sslEnabled) {
-//            SslOptions sslOptions = null;
-//            try {
-//                sslOptions = SslOptions.builder()
-//                        .trustManager(resourceLoader.getResource("classpath:secret/redis.pem").getFile())
-//                        .build();
-//            } catch (IOException e) {
-//                throw new RuntimeException(e);
-//            }
-//
-//            ClientOptions clientOptions = ClientOptions
-//                    .builder()
-//                    .sslOptions(sslOptions)
-//                    .protocolVersion(ProtocolVersion.RESP3)
-//                    .build();
-//
-//            lettuceClientConfigurationBuilder
-//                    .clientOptions(clientOptions)
-//                    .useSsl();
-//        }
-//
-//        LettuceClientConfiguration lettuceClientConfiguration = lettuceClientConfigurationBuilder.build();
-//
-//        return new LettuceConnectionFactory(redisStandaloneConfiguration, lettuceClientConfiguration);
-//    }
 
     @Bean
     RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {

--- a/src/main/java/com/moim/backend/global/util/DistanceCalculator.java
+++ b/src/main/java/com/moim/backend/global/util/DistanceCalculator.java
@@ -1,6 +1,6 @@
 package com.moim.backend.global.util;
 
-public final class DistanceCalculator {
+public class DistanceCalculator {
 
     private static final int EARTH_RADIUS = 6371;
     private static final int KM_TO_M = 1000;

--- a/src/test/java/com/moim/backend/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/moim/backend/domain/user/service/UserServiceTest.java
@@ -6,19 +6,14 @@ import com.moim.backend.domain.user.repository.UserRepository;
 import com.moim.backend.domain.user.response.UserResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 import static com.moim.backend.domain.user.config.Platform.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -56,7 +51,7 @@ class UserServiceTest {
         );
 
         // then
-        assertThat(response.getToken()).isNotNull();
+        assertThat(response.getAccessToken()).isNotNull();
 
         assertThat(response)
                 .extracting("email", "name")

--- a/src/test/java/com/moim/backend/global/TestRedisConfig.java
+++ b/src/test/java/com/moim/backend/global/TestRedisConfig.java
@@ -1,0 +1,2 @@
+package com.moim.backend.global;public class TestRedisConfig {
+}

--- a/src/test/java/com/moim/backend/global/auth/jwt/JwtServiceTest.java
+++ b/src/test/java/com/moim/backend/global/auth/jwt/JwtServiceTest.java
@@ -1,6 +1,5 @@
 package com.moim.backend.global.auth.jwt;
 
-import com.moim.backend.TestQueryDSLConfig;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.security.SignatureException;
 import org.junit.jupiter.api.DisplayName;
@@ -8,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 
 import java.util.Optional;
 
@@ -29,7 +27,7 @@ public class JwtServiceTest {
         String mail = "test@gmail.com";
 
         // when
-        String token = jwtService.createToken(mail);
+        String token = jwtService.createAccessToken(mail);
         String tokenPattern = ".+\\..+\\..+";
 
         // then
@@ -51,12 +49,12 @@ public class JwtServiceTest {
     protected void invalidSignatureTest() {
         // given
         String mail = "test@gmail.com";
-        String token = jwtService.createToken(mail);
+        String token = jwtService.createAccessToken(mail);
 
         // when // then
         assertThrows(
                 SignatureException.class,
-                () -> jwtService.isValidated(token.substring(0, token.length() - 2))
+                () -> jwtService.validateToken(token.substring(0, token.length() - 2))
         );
     }
 
@@ -65,12 +63,12 @@ public class JwtServiceTest {
     protected void invalidHeaderTest() {
         // given
         String mail = "test@gmail.com";
-        String token = jwtService.createToken(mail);
+        String token = jwtService.createAccessToken(mail);
 
         // when // then
         assertThrows(
                 MalformedJwtException.class,
-                () -> jwtService.isValidated(token.substring(1))
+                () -> jwtService.validateToken(token.substring(1))
         );
     }
 


### PR DESCRIPTION
## 로그인 로직 흐름
1. 로그인 api 요청
2. atk 생성
3. rtk 생성
4. redis에 rtk 저장

## 엑세스 토큰 재발급 흐름
1. 재발급 api 요청
2. rtk 만료시간 검증
3. 만료가 되지 않았다면, redis에서 해당 유저의 rtk 조회
4. redis에서 조회한 값과 header로 전달받은 rtk가 같다면 엑세스 토큰 발급