### PR TITLE
chore: 캐싱 로직 추가 및 로그 파일 분리

### DIFF
--- a/src/main/java/com/moim/backend/BackendApplication.java
+++ b/src/main/java/com/moim/backend/BackendApplication.java
@@ -2,7 +2,6 @@ package com.moim.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.EnableAspectJAutoProxy;
 
 @SpringBootApplication
 public class BackendApplication {

--- a/src/main/java/com/moim/backend/domain/space/service/DirectionService.java
+++ b/src/main/java/com/moim/backend/domain/space/service/DirectionService.java
@@ -1,0 +1,94 @@
+package com.moim.backend.domain.space.service;
+
+import com.moim.backend.domain.space.config.OdsayProperties;
+import com.moim.backend.domain.space.entity.Groups;
+import com.moim.backend.domain.space.entity.Participation;
+import com.moim.backend.domain.space.response.BusGraphicDataResponse;
+import com.moim.backend.domain.space.response.BusPathResponse;
+import com.moim.backend.domain.space.response.CarMoveInfo;
+import com.moim.backend.domain.space.response.PlaceRouteResponse;
+import com.moim.backend.domain.subway.response.BestPlaceInterface;
+import com.moim.backend.domain.user.config.KakaoProperties;
+import com.moim.backend.global.aspect.TimeCheck;
+import com.moim.backend.global.util.LoggingUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class DirectionService {
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final OdsayProperties odsayProperties;
+    private final KakaoProperties kakaoProperties;
+
+    @TimeCheck
+    public Optional<PlaceRouteResponse.MoveUserInfo> getBusRouteToResponse(
+            BestPlaceInterface bestPlace, Groups group, Participation participation
+    ) {
+        Optional<PlaceRouteResponse.MoveUserInfo> moveUserInfo = Optional.empty();
+        URI searchPathUri = odsayProperties.getSearchPathUriWithParams(bestPlace, participation);
+        BusPathResponse busPathResponse = restTemplate.getForObject(searchPathUri, BusPathResponse.class);
+
+        if (busPathResponse.getResult() == null) {
+            LoggingUtil.builder()
+                    .title("버스 길찾기")
+                    .status("실패")
+                    .message("지역: " + bestPlace.getName() + ", url: " + searchPathUri)
+                    .build()
+                    .print();
+        } else {
+            URI graphicDataUri = odsayProperties.getGraphicDataUriWIthParams(busPathResponse.getPathInfoMapObj());
+            BusGraphicDataResponse busGraphicDataResponse = restTemplate.getForObject(
+                    graphicDataUri, BusGraphicDataResponse.class
+            );
+            if (busPathResponse.getResult() == null) {
+                LoggingUtil.builder()
+                        .title("버스 그래픽 데이터 조회")
+                        .status("실패")
+                        .message("지역: " + bestPlace.getName() + ", url: " + graphicDataUri)
+                        .build()
+                        .print();
+            } else {
+                moveUserInfo = Optional.of(new PlaceRouteResponse.MoveUserInfo(group, participation, busGraphicDataResponse, busPathResponse));
+            }
+        }
+        return moveUserInfo;
+    }
+
+    @TimeCheck
+    public Optional<PlaceRouteResponse.MoveUserInfo> getCarRouteToResponse(
+            BestPlaceInterface bestPlace, Groups group, Participation participation
+    ) {
+        Optional<PlaceRouteResponse.MoveUserInfo> moveUserInfo = Optional.empty();
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "KakaoAK " + kakaoProperties.getClientId());
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        URI searchCarPathUri = kakaoProperties.getSearchCarPathUriWithParams(bestPlace, participation);
+        CarMoveInfo carMoveInfo = restTemplate.exchange(
+                searchCarPathUri, HttpMethod.GET, new HttpEntity<>(headers), CarMoveInfo.class
+        ).getBody();
+        if (carMoveInfo.getRoutes() == null) {
+            LoggingUtil.builder()
+                    .title("차 길찾기")
+                    .status("실패")
+                    .message("지역: " + bestPlace.getName() + ", url: " + searchCarPathUri)
+                    .build()
+                    .print();
+        } else {
+            moveUserInfo = Optional.of(new PlaceRouteResponse.MoveUserInfo(group, participation, carMoveInfo));
+        }
+        return moveUserInfo;
+    }
+
+}

--- a/src/main/java/com/moim/backend/global/aspect/PerformanceAspect.java
+++ b/src/main/java/com/moim/backend/global/aspect/PerformanceAspect.java
@@ -4,14 +4,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
 import org.springframework.stereotype.Component;
 
 @Aspect
 @Component
 @Slf4j
 public class PerformanceAspect {
-    @Around("execution(* com.moim.backend.domain..controller.*.*(..))")
-    public Object measureMethodExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+    @Around("execution(* com.moim.backend.domain..controller.*.*(..)) || @annotation(com.moim.backend.global.aspect.TimeCheck)")
+    public Object measureClassMethodExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
         long startTime = System.currentTimeMillis();
         Object returnValue = joinPoint.proceed();
         long totalTime = System.currentTimeMillis() - startTime;

--- a/src/main/java/com/moim/backend/global/aspect/TimeCheck.java
+++ b/src/main/java/com/moim/backend/global/aspect/TimeCheck.java
@@ -1,0 +1,11 @@
+package com.moim.backend.global.aspect;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TimeCheck {
+}

--- a/src/main/java/com/moim/backend/global/common/CacheName.java
+++ b/src/main/java/com/moim/backend/global/common/CacheName.java
@@ -1,0 +1,5 @@
+package com.moim.backend.global.common;
+
+public class CacheName {
+    public static final String group = "group";
+}

--- a/src/main/java/com/moim/backend/global/config/RedisCacheConfig.java
+++ b/src/main/java/com/moim/backend/global/config/RedisCacheConfig.java
@@ -1,0 +1,25 @@
+package com.moim.backend.global.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+    @Bean
+    public CacheManager contentCacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory).cacheDefaults(redisCacheConfiguration).build();
+    }
+}

--- a/src/main/java/com/moim/backend/global/config/RedisConfig.java
+++ b/src/main/java/com/moim/backend/global/config/RedisConfig.java
@@ -8,6 +8,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 
 @Configuration
@@ -28,6 +29,8 @@ public class RedisConfig {
     RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
         RedisTemplate<String, String> template = new RedisTemplate<>();
         template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
         return template;
     }
 

--- a/src/main/java/com/moim/backend/global/filter/TimeCheckFilter.java
+++ b/src/main/java/com/moim/backend/global/filter/TimeCheckFilter.java
@@ -1,0 +1,14 @@
+package com.moim.backend.global.filter;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+
+public class TimeCheckFilter extends Filter<ILoggingEvent> {
+    @Override
+    public FilterReply decide(ILoggingEvent event) {
+        return (event.getLoggerName().equals("com.moim.backend.global.aspect.PerformanceAspect"))
+                ? FilterReply.ACCEPT
+                : FilterReply.DENY;
+    }
+}

--- a/src/main/java/com/moim/backend/global/util/LoggingUtil.java
+++ b/src/main/java/com/moim/backend/global/util/LoggingUtil.java
@@ -1,0 +1,18 @@
+package com.moim.backend.global.util;
+
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Builder
+public class LoggingUtil {
+    private String title;
+    private String status = "";
+    private String message;
+
+    public void print() {
+        log.info("[ {} {} ] ========================================", title, status);
+        log.info(message);
+        log.info("=================================================================");
+    }
+}

--- a/src/main/java/com/moim/backend/global/util/RedisDao.java
+++ b/src/main/java/com/moim/backend/global/util/RedisDao.java
@@ -1,6 +1,7 @@
 package com.moim.backend.global.util;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Component;
@@ -11,12 +12,17 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-public class RedisDao {
+public class RedisDao implements InitializingBean {
     private final RedisTemplate<String, String> redisTemplate;
+    private ValueOperations<String, String> valueOperations;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        valueOperations = redisTemplate.opsForValue();
+    }
 
     public void setValues(String key, String data) {
-        ValueOperations<String, String> values = redisTemplate.opsForValue();
-        values.set(key, data);
+        valueOperations.set(key, data);
     }
 
     public void setValuesList(String key, String data) {
@@ -29,16 +35,18 @@ public class RedisDao {
     }
 
     public void setValues(String key, String data, Duration duration) {
-        ValueOperations<String, String> values = redisTemplate.opsForValue();
-        values.set(key, data, duration);
+        valueOperations.set(key, data, duration);
     }
 
     public String getValues(String key) {
-        ValueOperations<String, String> values = redisTemplate.opsForValue();
-        return values.get(key);
+        return valueOperations.get(key);
     }
 
     public void deleteValues(String key) {
         redisTemplate.delete(key);
+    }
+
+    public void deleteSpringCache(String name, String key) {
+        redisTemplate.delete(name + "::" + key);
     }
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,11 +1,66 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <configuration>
+    <property name="CONSOLE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %highlight(%-5level) %cyan(%logger) - %msg%n"/>
+    <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n"/>
+    <property name="LOG_PATH" value="../logs"/>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %highlight(%5level) %cyan(%logger) - %msg%n</pattern>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
         </encoder>
     </appender>
+    <appender name="TIME-CHECK" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="com.moim.backend.global.filter.TimeCheckFilter"/>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/time-check/%d{yyyy-MM-dd}_%i.log</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <!-- 파일당 최대 용량 -->
+                <maxFileSize>10MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <!-- 일자별 로그파일 최대 30일 동안 보관-->
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+    </appender>
+    <appender name="WARNING-FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>warn</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/warning/warning.%d{yyyy-MM-dd}_%i.log</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>10MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+    </appender>
+    <appender name="ERROR-FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>error</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/error/error.%d{yyyy-MM-dd}_%i.log</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>10MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+    </appender>
     <root level="DEBUG">
-        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="TIME-CHECK"/>
+        <appender-ref ref="WARNING-FILE"/>
+        <appender-ref ref="ERROR-FILE"/>
     </root>
 </configuration>


### PR DESCRIPTION
## 시간 측정용 어노테이션 추가
* 특정 클래스가 아닌 특정 메서드의 속도를 측정하는 어노테이션 `@TimeCheck` 추가
* `@TimeCheck`가 달린 메서드는 속도 측정 대상
## 캐싱 로직 추가
* 모임 추천 지역 시 캐싱
* 캐시 삭제 시점: 모임 참여하기, 모임 나가기, 모임 삭제
* 모임 나가기 시에는 초반에 그룹 아이디를 모르기 때문에, 중간에 redisdao 를 이용해 삭제
* spring 의 cache 관련 어노테이션으로 redis에 "name::key"와 같이 "::"로 구분되기 때문에, name과 key를 파라미터로 받는 삭제 메서드 생성
## 로그 파일 분리
* 분리 목적: HikariPool 관련 로그가 쌓여서 속도나 에러 관련 로그를 찾기 힘들어서 파일로 분리
* 분리하는 파일: 측정 속도, 레벨이 warn 또는 error 인 로그