### PR TITLE
feat: 내 모임 확인하기 API에서 장소 이름으로 검색 가능하게끔 선택적 파라미터 추가

### DIFF
--- a/src/main/java/com/moim/backend/domain/space/controller/SpaceController.java
+++ b/src/main/java/com/moim/backend/domain/space/controller/SpaceController.java
@@ -117,9 +117,10 @@ public class SpaceController {
     // 내 모임 확인하기 API
     @GetMapping("/participate")
     public CustomResponseEntity<List<SpaceMyParticipateResponse>> getMyParticipate(
-            @Login Users user
+            @Login Users user,
+            @RequestParam(required = false) String spaceName
     ) {
-        return CustomResponseEntity.success(spaceService.getMyParticipate(user));
+        return CustomResponseEntity.success(spaceService.getMyParticipate(user, spaceName));
     }
 
     // 모임 장소 추천 조회 리스트 API

--- a/src/main/java/com/moim/backend/domain/space/repository/SpaceCustomRepository.java
+++ b/src/main/java/com/moim/backend/domain/space/repository/SpaceCustomRepository.java
@@ -1,6 +1,7 @@
 package com.moim.backend.domain.space.repository;
 
 import com.moim.backend.domain.space.entity.Space;
+import com.moim.backend.domain.user.entity.Users;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,5 +10,6 @@ import java.util.Optional;
 @Repository
 public interface SpaceCustomRepository {
     List<Space> findBySpaceFetch(Long userId);
+    List<Space> findBySpaceFetch(Long userId, String name);
     Optional<Space> findBySpaceParticipation(Long groupId);
 }

--- a/src/main/java/com/moim/backend/domain/space/service/SpaceService.java
+++ b/src/main/java/com/moim/backend/domain/space/service/SpaceService.java
@@ -238,8 +238,10 @@ public class SpaceService {
     }
 
     // 내 모임 확인하기
-    public List<SpaceMyParticipateResponse> getMyParticipate(Users user) {
-        List<Space> groups = groupRepository.findBySpaceFetch(user.getUserId());
+    public List<SpaceMyParticipateResponse> getMyParticipate(Users user, String spaceName) {
+        List<Space> groups = (spaceName == null)
+                ? groupRepository.findBySpaceFetch(user.getUserId())
+                : groupRepository.findBySpaceFetch(user.getUserId(), spaceName);
 
         return groups.stream()
                 .map(group -> toMyParticiPateResponse(group, user))

--- a/src/test/java/com/moim/backend/docs/space/SpaceControllerDocsTest.java
+++ b/src/test/java/com/moim/backend/docs/space/SpaceControllerDocsTest.java
@@ -524,7 +524,7 @@ public class SpaceControllerDocsTest extends RestDocsSupport {
                 .participantNames(List.of("양파쿵야", "주먹밥쿵야", "샐러리쿵야"))
                 .build();
 
-        given(spaceService.getMyParticipate(any()))
+        given(spaceService.getMyParticipate(any(), anyString()))
                 .willReturn(List.of(data1, data2));
 
         MockHttpServletRequestBuilder httpRequest = RestDocumentationRequestBuilders.get("/group/participate")

--- a/src/test/java/com/moim/backend/domain/space/service/SpaceServiceTest.java
+++ b/src/test/java/com/moim/backend/domain/space/service/SpaceServiceTest.java
@@ -559,7 +559,7 @@ class SpaceServiceTest {
         em.clear();
 
         // when
-        List<SpaceMyParticipateResponse> response = spaceService.getMyParticipate(user1);
+        List<SpaceMyParticipateResponse> response = spaceService.getMyParticipate(user1, null);
 
         // then
         assertThat(response).hasSize(3);
@@ -585,7 +585,7 @@ class SpaceServiceTest {
         em.clear();
 
         // when
-        List<SpaceMyParticipateResponse> response = spaceService.getMyParticipate(admin1);
+        List<SpaceMyParticipateResponse> response = spaceService.getMyParticipate(admin1, null);
 
         // then
         assertThat(response).isEmpty();


### PR DESCRIPTION
* 내 모임 확인하기 API에 추가한 파라미터
  * 이름: spaceName
  * 타입: 문자열
  * 필수 여부: 선택
* 기존에 사용하던 API와 Repository의 메서드를 사용하기 위해 findBySpaceFetch 를 오버로딩하여 유저 아이디와 장소 이름을 받는 메서드를 추가함