### PR TITLE
feat: 검색 API 개발

### DIFF
--- a/src/main/java/com/moim/backend/domain/space/controller/SpaceController.java
+++ b/src/main/java/com/moim/backend/domain/space/controller/SpaceController.java
@@ -6,6 +6,7 @@ import com.moim.backend.domain.space.request.SpaceParticipateRequest;
 import com.moim.backend.domain.space.request.SpaceParticipateUpdateRequest;
 import com.moim.backend.domain.space.response.NicknameValidationResponse;
 import com.moim.backend.domain.space.response.PlaceRouteResponse;
+import com.moim.backend.domain.space.response.SpaceFilterEnum;
 import com.moim.backend.domain.space.response.space.*;
 import com.moim.backend.domain.space.service.SpaceService;
 import com.moim.backend.domain.user.entity.Users;
@@ -118,9 +119,10 @@ public class SpaceController {
     @GetMapping("/participate")
     public CustomResponseEntity<List<SpaceMyParticipateResponse>> getMyParticipate(
             @Login Users user,
-            @RequestParam(required = false) String spaceName
+            @RequestParam(required = false) String spaceName,
+            @RequestParam(required = false) SpaceFilterEnum filter
     ) {
-        return CustomResponseEntity.success(spaceService.getMyParticipate(user, spaceName));
+        return CustomResponseEntity.success(spaceService.getMyParticipate(user, spaceName, filter));
     }
 
     // 모임 장소 추천 조회 리스트 API

--- a/src/main/java/com/moim/backend/domain/space/repository/SpaceCustomRepository.java
+++ b/src/main/java/com/moim/backend/domain/space/repository/SpaceCustomRepository.java
@@ -1,6 +1,7 @@
 package com.moim.backend.domain.space.repository;
 
 import com.moim.backend.domain.space.entity.Space;
+import com.moim.backend.domain.space.response.SpaceFilterEnum;
 import com.moim.backend.domain.user.entity.Users;
 import org.springframework.stereotype.Repository;
 
@@ -9,7 +10,7 @@ import java.util.Optional;
 
 @Repository
 public interface SpaceCustomRepository {
-    List<Space> findBySpaceFetch(Long userId);
-    List<Space> findBySpaceFetch(Long userId, String name);
+    List<Space> findBySpaceFetch(Long userId, SpaceFilterEnum filter);
+    List<Space> findBySpaceFetch(Long userId, String name, SpaceFilterEnum filter);
     Optional<Space> findBySpaceParticipation(Long groupId);
 }

--- a/src/main/java/com/moim/backend/domain/space/response/SpaceFilterEnum.java
+++ b/src/main/java/com/moim/backend/domain/space/response/SpaceFilterEnum.java
@@ -1,0 +1,14 @@
+package com.moim.backend.domain.space.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SpaceFilterEnum {
+    ABC("가나다순"),
+    LATEST("최신 순"),
+    OLDEST("오래된 순");
+
+    private final String name;
+}

--- a/src/main/java/com/moim/backend/domain/space/service/SpaceService.java
+++ b/src/main/java/com/moim/backend/domain/space/service/SpaceService.java
@@ -4,6 +4,7 @@ import com.moim.backend.domain.space.request.SpaceCreateRequest;
 import com.moim.backend.domain.space.request.SpaceNameUpdateRequest;
 import com.moim.backend.domain.space.request.SpaceParticipateRequest;
 import com.moim.backend.domain.space.request.SpaceParticipateUpdateRequest;
+import com.moim.backend.domain.space.response.SpaceFilterEnum;
 import com.moim.backend.domain.spacevote.entity.Vote;
 import com.moim.backend.domain.spacevote.repository.VoteRepository;
 import com.moim.backend.domain.hotplace.repository.HotPlaceRepository;
@@ -238,10 +239,10 @@ public class SpaceService {
     }
 
     // 내 모임 확인하기
-    public List<SpaceMyParticipateResponse> getMyParticipate(Users user, String spaceName) {
+    public List<SpaceMyParticipateResponse> getMyParticipate(Users user, String spaceName, SpaceFilterEnum filter) {
         List<Space> groups = (spaceName == null)
-                ? groupRepository.findBySpaceFetch(user.getUserId())
-                : groupRepository.findBySpaceFetch(user.getUserId(), spaceName);
+                ? groupRepository.findBySpaceFetch(user.getUserId(), filter)
+                : groupRepository.findBySpaceFetch(user.getUserId(), spaceName, filter);
 
         return groups.stream()
                 .map(group -> toMyParticiPateResponse(group, user))

--- a/src/test/java/com/moim/backend/docs/space/SpaceControllerDocsTest.java
+++ b/src/test/java/com/moim/backend/docs/space/SpaceControllerDocsTest.java
@@ -524,11 +524,13 @@ public class SpaceControllerDocsTest extends RestDocsSupport {
                 .participantNames(List.of("양파쿵야", "주먹밥쿵야", "샐러리쿵야"))
                 .build();
 
-        given(spaceService.getMyParticipate(any(), anyString()))
+        given(spaceService.getMyParticipate(any(), any(), any()))
                 .willReturn(List.of(data1, data2));
 
         MockHttpServletRequestBuilder httpRequest = RestDocumentationRequestBuilders.get("/group/participate")
-                .header(AUTHORIZATION, "Bearer {token}");
+                .header(AUTHORIZATION, "Bearer {token}")
+                .param("spaceName", "검색이름")
+                .param("filter", "ABC");
 
         ResourceSnippetParameters parameters = ResourceSnippetParameters.builder()
                 .tag("스페이스 API")
@@ -537,6 +539,10 @@ public class SpaceControllerDocsTest extends RestDocsSupport {
                         headerWithName("Authorization")
                                 .description("Swagger 요청시 해당 입력칸이 아닌 우측 상단 자물쇠 " +
                                         "또는 Authorize 버튼을 이용해 토큰을 넣어주세요"))
+                .queryParameters(
+                        parameterWithName("spaceName").description("검색하고 싶은 장소 이름. 해당 이름 포함하는 스페이스 조회 가능."),
+                        parameterWithName("filter").description("정렬 기준. ABC: 가나다순, LATEST: 최신순, OLDEST: 오래된 순")
+                )
                 .responseFields(
                         fieldWithPath("code").type(NUMBER)
                                 .description("상태 코드"),

--- a/src/test/java/com/moim/backend/domain/space/repository/GroupRepositoryTest.java
+++ b/src/test/java/com/moim/backend/domain/space/repository/GroupRepositoryTest.java
@@ -89,7 +89,7 @@ class GroupRepositoryTest {
         em.clear();
 
         // when
-        List<Space> spaces = groupRepository.findBySpaceFetch(user1.getUserId());
+        List<Space> spaces = groupRepository.findBySpaceFetch(user1.getUserId(), null);
 
         // then
         assertThat(spaces).hasSize(3)


### PR DESCRIPTION
* 관련 이슈: #118 
* 내가 참여하고 있는 정보 조회 시 이름 검색과 필터링 기능 추가
* 추가한 파리미터
  * spaceName: 검색을 원하는 장소 이름
  * filter: 필터 기준. ABC, LATEST, OLDEST 중 하나 전달. (ABC: 가나다순, LATEST: 최신순, OLDEST: 오래된 순)