### PR TITLE
fix: 경로 끊기는 문제 해결

### DIFF
--- a/src/main/java/com/moim/backend/domain/space/response/BusGraphicDataResponse.java
+++ b/src/main/java/com/moim/backend/domain/space/response/BusGraphicDataResponse.java
@@ -1,6 +1,7 @@
 package com.moim.backend.domain.space.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.moim.backend.domain.space.entity.BestPlace;
 import com.moim.backend.domain.space.entity.Participation;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,12 +21,15 @@ public class BusGraphicDataResponse implements PathGraphicDataInterface {
     }
 
     @Override
-    public List<PathDto> getPathList(Participation participation) {
+    public List<PathDto> getPathList(Participation participation, BestPlace bestPlace) {
         List<PathDto> path = new ArrayList<>();
         path.add(PathDto.builder().latitude(participation.getLatitude()).longitude(participation.getLongitude()).build());
-        result.lane.get(0).section.forEach(section -> {
-            path.addAll(section.graphPos);
-        });
+        for (Lane lane : result.lane) {
+            for (Section section : lane.section) {
+                path.addAll(section.graphPos);
+            }
+        }
+        path.add(new PathDto(bestPlace.getLongitude(), bestPlace.getLatitude()));
         return path;
     }
 

--- a/src/main/java/com/moim/backend/domain/space/response/CarMoveInfo.java
+++ b/src/main/java/com/moim/backend/domain/space/response/CarMoveInfo.java
@@ -1,6 +1,7 @@
 package com.moim.backend.domain.space.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.moim.backend.domain.space.entity.BestPlace;
 import com.moim.backend.domain.space.entity.Participation;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -49,12 +50,15 @@ public class CarMoveInfo implements MoveInfoInterface, PathGraphicDataInterface 
     }
 
     @Override
-    public List<PathDto> getPathList(Participation participation) {
+    public List<PathDto> getPathList(Participation participation, BestPlace bestPlace) {
         // 위도, 경도 구분 없이 배열로 존재하여 vertexes를 Path 리스트로 변환
         // 짝수 인덱스: 경도, 홀스 인덱스: 위도
         List<PathDto> path = new ArrayList<>();
         path.add(PathDto.builder().latitude(participation.getLatitude()).longitude(participation.getLongitude()).build());
-        getBestRouteSection().roads.stream().forEach(road -> addVertexToPathList(road.vertexes, path));
+        for (Road road : getBestRouteSection().roads) {
+            addVertexToPathList(road.vertexes, path);
+        }
+        path.add(new PathDto(bestPlace.getLongitude(), bestPlace.getLatitude()));
         return path;
     }
 

--- a/src/main/java/com/moim/backend/domain/space/response/PathGraphicDataInterface.java
+++ b/src/main/java/com/moim/backend/domain/space/response/PathGraphicDataInterface.java
@@ -1,11 +1,12 @@
 package com.moim.backend.domain.space.response;
 
+import com.moim.backend.domain.space.entity.BestPlace;
 import com.moim.backend.domain.space.entity.Participation;
 
 import java.util.List;
 
 public interface PathGraphicDataInterface {
 
-    public List<PathDto> getPathList(Participation participation);
+    public List<PathDto> getPathList(Participation participation, BestPlace bestPlace);
 
 }

--- a/src/main/java/com/moim/backend/domain/space/response/PlaceRouteResponse.java
+++ b/src/main/java/com/moim/backend/domain/space/response/PlaceRouteResponse.java
@@ -49,7 +49,8 @@ public class PlaceRouteResponse {
                 Space group,
                 Participation participation,
                 BusGraphicDataResponse busGraphicDataResponse,
-                BusPathResponse busPathResponse
+                BusPathResponse busPathResponse,
+                BestPlace bestPlace
         ) {
             this.isAdmin = (participation.getUserId() == group.getAdminId()) ? true : false;
             this.userId = participation.getUserId();
@@ -58,14 +59,15 @@ public class PlaceRouteResponse {
             this.transitCount = busPathResponse.getTotalTransitCount();
             this.totalTime = busPathResponse.getTotalTime();
             this.totalDistance = busPathResponse.getTotalDistance();
-            this.path = busGraphicDataResponse.getPathList(participation);
+            this.path = busGraphicDataResponse.getPathList(participation, bestPlace);
             this.payment = busPathResponse.getPayment();
         }
 
         public MoveUserInfo(
                 Space group,
                 Participation participation,
-                CarMoveInfo carMoveInfo
+                CarMoveInfo carMoveInfo,
+                BestPlace bestPlace
         ) {
             this.isAdmin = (participation.getUserId() == group.getAdminId()) ? true : false;
             this.userId = participation.getUserId();
@@ -73,7 +75,7 @@ public class PlaceRouteResponse {
             this.transportationType = participation.getTransportation();
             this.totalTime = carMoveInfo.getTotalTime();
             this.totalDistance = carMoveInfo.getTotalDistance();
-            this.path = carMoveInfo.getPathList(participation);
+            this.path = carMoveInfo.getPathList(participation, bestPlace);
             this.payment = carMoveInfo.getPayment();
         }
     }

--- a/src/main/java/com/moim/backend/domain/space/service/DirectionService.java
+++ b/src/main/java/com/moim/backend/domain/space/service/DirectionService.java
@@ -59,7 +59,9 @@ public class DirectionService {
                         .build()
                         .print();
             } else {
-                moveUserInfo = Optional.of(new PlaceRouteResponse.MoveUserInfo(group, participation, busGraphicDataResponse, busPathResponse));
+                moveUserInfo = Optional.of(new PlaceRouteResponse.MoveUserInfo(
+                        group, participation, busGraphicDataResponse, busPathResponse, bestPlace
+                ));
             }
         }
         return moveUserInfo;
@@ -86,7 +88,7 @@ public class DirectionService {
                     .build()
                     .print();
         } else {
-            moveUserInfo = Optional.of(new PlaceRouteResponse.MoveUserInfo(group, participation, carMoveInfo));
+            moveUserInfo = Optional.of(new PlaceRouteResponse.MoveUserInfo(group, participation, carMoveInfo, bestPlace));
         }
         return moveUserInfo;
     }


### PR DESCRIPTION
* 관련 요청사항: https://www.notion.so/API-path-totalTime-dcdf553d06c242aabbce8e7030c3f66c
## 시간이 비정상적으로 긴 문제
* 예시: groupId 가 48일 때, 햄버거의 시간이 1549분으로 나옴
* 원인: 자동차 길찾기의 경우 총 시간 단위가 초 였음

## 경로가 끊겨서 그려지는 문제
* 예시: groupId가 48일 때, 피자의 경로가 모두 그려지지 않음
* 원인: 경로가 버스 노선 타입에 따라 lane list로 오는데, 그 중 가장 첫 데이터만 사용하고 있었음. 모두 사용하는 방법으로 수정함
* 문제의 코드 부분
```java
        result.lane.get(0).section.forEach(section -> {
            path.addAll(section.graphPos);
        });
```