### PR TITLE
fix: 회원탈퇴 후 참여하고 있는 모임 조회 시 500 error

### DIFF
--- a/src/main/java/com/moim/backend/global/auth/LoginInterceptor.java
+++ b/src/main/java/com/moim/backend/global/auth/LoginInterceptor.java
@@ -4,7 +4,6 @@ import com.moim.backend.global.auth.jwt.JwtService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -28,8 +27,12 @@ public class LoginInterceptor implements HandlerInterceptor {
 
         String authorization = request.getHeader(AUTHORIZATION);
         if (authorization != null) {
-            String token = jwtService.getToken(Optional.of(authorization));
-            jwtService.validateToken(token);
+            try {
+                String token = jwtService.getToken(Optional.of(authorization));
+                jwtService.validateToken(token);
+            } catch (Exception e) {
+                return false;
+            }
         }
 
         return true;

--- a/src/main/java/com/moim/backend/global/auth/jwt/JwtService.java
+++ b/src/main/java/com/moim/backend/global/auth/jwt/JwtService.java
@@ -1,7 +1,5 @@
 package com.moim.backend.global.auth.jwt;
 
-import com.moim.backend.global.common.RedisKeyPrefix;
-import com.moim.backend.global.common.Result;
 import com.moim.backend.global.common.exception.CustomException;
 import com.moim.backend.global.util.RedisDao;
 import io.jsonwebtoken.Claims;
@@ -64,11 +62,7 @@ public class JwtService implements InitializingBean {
         if (redisDao.getValues(token) != null) {
             throw new CustomException(IS_TOKEN_LOGOUT);
         }
-        try {
-            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
-        } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("JWT 토큰이 잘못되었습니다.");
-        }
+        Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
     }
 
     public void validateRefreshToken(String token) {


### PR DESCRIPTION
회원탈퇴 후 임의로 토큰을 삭제했을 경우, 아래와 같이 io.jsonwebtoken.MalformedJwtException 에러가 발생하는데, 글로벌 예외 핸들러에서 못 잡고 있었음. 따라서 try catch 문 제거하고 전역적으로 잡을 수 있도록 처리

<img width="1439" alt="스크린샷 2024-05-23 오후 9 46 05" src="https://github.com/moidot/backend/assets/68562176/5a584245-fddf-41f6-a046-7ee88bc2ab1e">
