### PR TITLE
fix: Bearer 형태의 토큰이 아닌 경우 로그아웃 시 500 에러 발생하는 문제 해결

### DIFF
--- a/src/main/java/com/moim/backend/domain/user/controller/AuthController.java
+++ b/src/main/java/com/moim/backend/domain/user/controller/AuthController.java
@@ -51,9 +51,9 @@ public class AuthController {
     @DeleteMapping("/logout")
     public CustomResponseEntity<Void> logout(
             @Login Users user,
-            @RequestHeader(value = "Authorization") String atk
+            @RequestHeader(value = "Authorization") String authorization
     ) {
-        return CustomResponseEntity.success(userService.logout(user, atk));
+        return CustomResponseEntity.success(userService.logout(user, authorization));
     }
 
     // 회원탈퇴 API

--- a/src/main/java/com/moim/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/moim/backend/domain/user/service/UserService.java
@@ -97,11 +97,11 @@ public class UserService {
     }
 
     // 로그아웃 API
-    public Void logout(Users user, String atk) {
-        String decodeAtk = atk.substring(7);
-        Long expiration = jwtService.getExpiration(decodeAtk);
+    public Void logout(Users user, String authorization) {
+        String token = jwtService.getToken(Optional.of(authorization));
+        Long expiration = jwtService.getExpiration(token);
 
-        return redisService.logoutFromRedis(user.getEmail(), decodeAtk, expiration);
+        return redisService.logoutFromRedis(user.getEmail(), token, expiration);
     }
 
     // 회원탈퇴 API


### PR DESCRIPTION
## 문제 상황
안드로이드 환경에서 로그아웃 시 아래와 같이 JsonParseException 에러 발생
웹에서는 잘되는 상황
<img width="1416" alt="스크린샷 2024-05-24 오전 12 35 18" src="https://github.com/moidot/backend/assets/68562176/7296744b-2d8d-4c57-a671-98b8bf47ca28">

## 문제 원인
`String decodeAtk = atk.substring(7);` 이 부분을 통해 로그아웃 시 Bearer {토큰} 형태로 오는 경우 토큰을 추출해서 사용했는데, Bearer 타입의 토큰이 아니라 바로 토큰으로 오는 경우 앞의 문자가 잘려서 파싱하는 데 에러가 발생함